### PR TITLE
[#17] TextEditor 컴포넌트 구현

### DIFF
--- a/frontend/src/App.style.ts
+++ b/frontend/src/App.style.ts
@@ -50,6 +50,10 @@ export const GlobalStyle = createGlobalStyle`
     appearance: none;
   }
 
+  textarea {
+    resize: none;
+  }
+
   a {
     font-weight: bold;
     font-size: 2rem;

--- a/frontend/src/assets/icons/index.tsx
+++ b/frontend/src/assets/icons/index.tsx
@@ -3,3 +3,4 @@ export { ReactComponent as PersonIcon } from "./person.svg";
 export { ReactComponent as AddBoxIcon } from "./add-box.svg";
 export { ReactComponent as SearchIcon } from "./search.svg";
 export { ReactComponent as LoginIcon } from "./login.svg";
+export { ReactComponent as CancelIcon } from "./cancel.svg";

--- a/frontend/src/components/@shared/Chip/Chip.tsx
+++ b/frontend/src/components/@shared/Chip/Chip.tsx
@@ -1,4 +1,4 @@
-import cancelIcon from "../../../assets/icons/cancel.svg";
+import { CancelIcon } from "../../../assets/icons";
 import { Container, DeleteButton, Text } from "./Chip.style";
 
 export interface Props extends React.HTMLAttributes<HTMLSpanElement> {
@@ -13,7 +13,7 @@ const Chip = ({ backgroundColor, children, onDelete }: Props) => {
       <Text>{children}</Text>
       {onDelete && (
         <DeleteButton onClick={onDelete}>
-          <img src={cancelIcon} alt="태그 삭제 아이콘" />
+          <CancelIcon />
         </DeleteButton>
       )}
     </Container>

--- a/frontend/src/components/@shared/TextEditor/TextEditor.stories.tsx
+++ b/frontend/src/components/@shared/TextEditor/TextEditor.stories.tsx
@@ -1,0 +1,45 @@
+import { Story } from "@storybook/react";
+import { ChangeEventHandler, useState } from "react";
+
+import TextEditor, { Props } from "./TextEditor";
+
+type ContainerProps = Omit<Props, "value" | "onChange">;
+
+const Container = (args: ContainerProps) => {
+  const [value, setValue] = useState("");
+  const onChange: ChangeEventHandler<HTMLTextAreaElement> = ({ target: { value } }) => setValue(value);
+
+  return <TextEditor value={value} onChange={onChange} {...args} />;
+};
+
+export default {
+  title: "Components/Shared/TextEditor",
+  component: Container,
+};
+
+const Template: Story<ContainerProps> = (args) => <Container {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  width: "100%",
+  height: "200px",
+  backgroundColor: "#efefef",
+  placeholder: "내용을 입력해주세요",
+};
+
+export const AutoGrow = Template.bind({});
+AutoGrow.args = {
+  width: "100%",
+  height: "200px",
+  backgroundColor: "#efefef",
+  placeholder: "내용을 입력해주세요",
+  autoGrow: true,
+};
+
+export const Transparent = Template.bind({});
+Transparent.args = {
+  width: "100%",
+  height: "200px",
+  placeholder: "내용을 입력해주세요",
+  autoGrow: true,
+};

--- a/frontend/src/components/@shared/TextEditor/TextEditor.style.ts
+++ b/frontend/src/components/@shared/TextEditor/TextEditor.style.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const TextArea = styled.textarea<React.CSSProperties>`
+  ${({ width, height, minHeight, backgroundColor }) => `
+    width: ${width ?? "100%"};
+    min-height: ${minHeight ?? "fit-content"};
+    height: ${height ?? "fit-content"};
+    background-color: ${backgroundColor ?? "transparent"};
+  `}
+
+  border: none;
+  outline: none;
+  border-radius: 4px;
+  padding: 1.1rem 1rem;
+`;
+
+export default TextArea;

--- a/frontend/src/components/@shared/TextEditor/TextEditor.tsx
+++ b/frontend/src/components/@shared/TextEditor/TextEditor.tsx
@@ -1,0 +1,56 @@
+import { ChangeEventHandler, KeyboardEventHandler, useState } from "react";
+
+import TextArea from "./TextEditor.style";
+
+export interface Props {
+  width?: string;
+  height?: string;
+  backgroundColor?: string;
+  fontSize?: string;
+  autoGrow?: boolean;
+  placeholder?: string;
+  value: string;
+  onChange: ChangeEventHandler<HTMLTextAreaElement>;
+}
+
+const TEXT_EDITOR_LINE_HEIGHT = 1.2;
+
+const TextEditor = ({
+  width,
+  height,
+  backgroundColor,
+  fontSize = "1rem",
+  autoGrow = false,
+  placeholder,
+  value,
+  onChange,
+}: Props) => {
+  const [currentHeight, setCurrentHeight] = useState("");
+
+  const onKeyUp: KeyboardEventHandler<HTMLTextAreaElement> = ({ key }) => {
+    if (!autoGrow) return;
+
+    if (key === "Enter" || key === "Backspace" || key === "Delete") {
+      const lineCount = (value ?? "").split("\n").length + 1;
+      const fontSizeNumber = fontSize.replace(/[^0-9]/g, "");
+      const fontSizeMeasure = fontSize.replace(/[0-9]/g, "");
+
+      setCurrentHeight(`${lineCount * Number(fontSizeNumber) * TEXT_EDITOR_LINE_HEIGHT}${fontSizeMeasure}`);
+    }
+  };
+
+  return (
+    <TextArea
+      width={width}
+      minHeight={height}
+      height={currentHeight}
+      backgroundColor={backgroundColor}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      onKeyUp={onKeyUp}
+    />
+  );
+};
+
+export default TextEditor;


### PR DESCRIPTION
## 상세 내용
TextEditor 컴포넌트 구현

- React.CSSProperties, HTMLTextElement 타입을 extends 하지 않음
  - width, heigth, fontSize의 타입을 string으로 강제
  - HTMLTextElement사용 시 알수 없는 충돌
- autoGrow prop이 true일 경우 작성한 글의 줄 수에 따라 textarea의 height도 늘어남

### [Storybook보기](https://beuccol-pick-git-storybook.netlify.app)
