### PR TITLE
[#4] ImageSlider 컴포넌트 구현

### DIFF
--- a/frontend/src/assets/icons/go-back.svg
+++ b/frontend/src/assets/icons/go-back.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22">
-  <g id="go-back-icon" transform="translate(2 5)">
-    <circle id="Path" cx="10" cy="10" r="10" transform="translate(-1 -4)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <path id="Path-2" data-name="Path" d="M12,8,8,12l4,4" transform="translate(-3 -6)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line id="Line" x1="8" transform="translate(5 6)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  <g id="go-back-icon" transform="translate(2 5)" fill="none" stroke="currentColor">
+    <circle id="Path" cx="10" cy="10" r="10" transform="translate(-1 -4)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <path id="Path-2" data-name="Path" d="M12,8,8,12l4,4" transform="translate(-3 -6)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <line id="Line" x1="8" transform="translate(5 6)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/frontend/src/assets/icons/go-forward.svg
+++ b/frontend/src/assets/icons/go-forward.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22">
-  <g id="go-forward-icon" transform="translate(2 5)">
-    <circle id="Path" cx="10" cy="10" r="10" transform="translate(-1 -4)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <path id="Path-2" data-name="Path" d="M12,16l4-4L12,8" transform="translate(-3 -6)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line id="Line" x2="8" transform="translate(5 6)" fill="none" stroke="#5a5a5a" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  <g id="go-forward-icon" transform="translate(2 5)" fill="none" stroke="currentColor">
+    <circle id="Path" cx="10" cy="10" r="10" transform="translate(-1 -4)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <path id="Path-2" data-name="Path" d="M12,16l4-4L12,8" transform="translate(-3 -6)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <line id="Line" x2="8" transform="translate(5 6)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/frontend/src/components/@layout/SearchHeader/SearchHeader.tsx
+++ b/frontend/src/components/@layout/SearchHeader/SearchHeader.tsx
@@ -15,7 +15,7 @@ const SearchHeader = ({}: Props) => {
   return (
     <Container>
       <GoBackLink onClick={handleGoBack}>
-        <GoBackIcon />
+        <GoBackIcon color="5a5a5a" />
       </GoBackLink>
       <SearchInputWrapper>
         <Input kind="rounded" />

--- a/frontend/src/components/@layout/SearchHeader/SearchHeader.tsx
+++ b/frontend/src/components/@layout/SearchHeader/SearchHeader.tsx
@@ -15,7 +15,7 @@ const SearchHeader = ({}: Props) => {
   return (
     <Container>
       <GoBackLink onClick={handleGoBack}>
-        <GoBackIcon color="5a5a5a" />
+        <GoBackIcon color="#5a5a5a" />
       </GoBackLink>
       <SearchInputWrapper>
         <Input kind="rounded" />

--- a/frontend/src/components/@layout/StepHeader/StepHeader.tsx
+++ b/frontend/src/components/@layout/StepHeader/StepHeader.tsx
@@ -20,12 +20,12 @@ const StepHeader = ({ goForwardLink, children }: Props) => {
   return (
     <Container>
       <StepLink onClick={handleGoBack}>
-        <GoBackIcon />
+        <GoBackIcon color="5a5a5a" />
       </StepLink>
       <Content>{children}</Content>
       {goForwardLink ? (
         <StepLink onClick={handleGoForward}>
-          <GoForwardIcon />
+          <GoForwardIcon color="5a5a5a" />
         </StepLink>
       ) : (
         <EmptySpace />

--- a/frontend/src/components/@layout/StepHeader/StepHeader.tsx
+++ b/frontend/src/components/@layout/StepHeader/StepHeader.tsx
@@ -20,12 +20,12 @@ const StepHeader = ({ goForwardLink, children }: Props) => {
   return (
     <Container>
       <StepLink onClick={handleGoBack}>
-        <GoBackIcon color="5a5a5a" />
+        <GoBackIcon color="#5a5a5a" />
       </StepLink>
       <Content>{children}</Content>
       {goForwardLink ? (
         <StepLink onClick={handleGoForward}>
-          <GoForwardIcon color="5a5a5a" />
+          <GoForwardIcon color="#5a5a5a" />
         </StepLink>
       ) : (
         <EmptySpace />

--- a/frontend/src/components/@shared/ImageSlider/ImageSlider.stories.tsx
+++ b/frontend/src/components/@shared/ImageSlider/ImageSlider.stories.tsx
@@ -1,0 +1,21 @@
+import { Story } from "@storybook/react";
+
+import ImageSlider, { Props } from "./ImageSlider";
+
+export default {
+  title: "Components/Shared/ImageSlider",
+  component: ImageSlider,
+};
+
+const Template: Story<Props> = (args) => <ImageSlider {...args} />;
+
+export const inBox = Template.bind({});
+inBox.args = {
+  imageUrls: [
+    "https://images.unsplash.com/photo-1625776730059-488c148cf868?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1825&q=80",
+    "https://images.unsplash.com/photo-1625777719145-b3a5ff913418?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80",
+    "https://images.unsplash.com/photo-1625851740514-6ce39269bc40?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1275&q=80",
+  ],
+  slideButtonKind: "in-box",
+  width: "100%",
+};

--- a/frontend/src/components/@shared/ImageSlider/ImageSlider.style.ts
+++ b/frontend/src/components/@shared/ImageSlider/ImageSlider.style.ts
@@ -1,0 +1,64 @@
+import styled from "styled-components";
+
+export const Container = styled.div<React.CSSProperties>`
+  ${({ width }) => `
+    width: ${width};
+  `}
+
+  overflow-x: hidden;
+  position: relative;
+`;
+
+export const ImageListSlider = styled.ul<React.CSSProperties>`
+  ${({ width }) => `
+    width: ${width};
+  `}
+  height: fit-content;
+  background-color: #000000;
+
+  display: flex;
+  align-items: center;
+  transition: transform 0.5s ease-in-out;
+`;
+
+export const ImageList = styled.li<React.CSSProperties>`
+  width: 100%;
+
+  img {
+    width: 100%;
+  }
+`;
+
+export const SlideButton = styled.button<{
+  direction: "left" | "right";
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  top: 50%;
+  ${({ direction }) => `
+    ${direction}: 0.25rem;
+  `}
+
+  transform: translateY(-50%);
+
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  opacity: 0.4;
+
+  ${({ theme }) => `
+    color: ${theme.color.white};
+    background-color: ${theme.color.primaryColor};
+  `}
+
+  :hover {
+    opacity: 0.7;
+  }
+
+  :active {
+    filter: brightness(1.2);
+  }
+`;

--- a/frontend/src/components/@shared/ImageSlider/ImageSlider.tsx
+++ b/frontend/src/components/@shared/ImageSlider/ImageSlider.tsx
@@ -1,0 +1,80 @@
+import { useContext, useEffect, useRef, useState } from "react";
+import { ThemeContext } from "styled-components";
+
+import { GoBackIcon, GoForwardIcon } from "../../../assets/icons/index";
+import useThrottle from "../../../services/hooks/@common/useThrottle";
+import { Container, ImageList, ImageListSlider, SlideButton } from "./ImageSlider.style";
+
+export interface Props extends React.CSSProperties {
+  imageUrls: string[];
+  slideButtonKind: "in-box" | "stick-out";
+}
+
+const SLIDE_THROTTLE_DELAY = 800;
+
+const ImageSlider = ({ imageUrls, slideButtonKind, width }: Props) => {
+  const [imageIndex, setImageIndex] = useState(0);
+  const [isFirstImage, setIsFirstImage] = useState(true);
+  const [isLastImage, setIsLastImage] = useState(false);
+
+  const theme = useContext(ThemeContext);
+  const imageCount = useRef(imageUrls.length);
+  const imageListSliderRef = useRef<HTMLUListElement>(null);
+
+  const onImageListSliderScroll: React.WheelEventHandler<HTMLUListElement> = useThrottle((event) => {
+    if (event.deltaX > 0 && !isLastImage) {
+      setImageIndex((prevIndex) => prevIndex + 1);
+    } else if (event.deltaX < 0 && !isFirstImage) {
+      setImageIndex((prevIndex) => prevIndex - 1);
+    }
+  }, SLIDE_THROTTLE_DELAY);
+
+  const onBackButtonClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    if (isFirstImage) return;
+
+    setImageIndex((prevIndex) => prevIndex - 1);
+  };
+
+  const onForwardButtonClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    if (isLastImage) return;
+
+    setImageIndex((prevIndex) => prevIndex + 1);
+  };
+
+  useEffect(() => {
+    setIsFirstImage(imageIndex === 0);
+    setIsLastImage(imageIndex === imageUrls.length - 1);
+
+    if (imageListSliderRef.current) {
+      imageListSliderRef.current.style.transform = `translateX(-${(100 * imageIndex) / imageUrls.length}%`;
+    }
+  }, [imageIndex, imageUrls.length]);
+
+  return (
+    <Container width={width}>
+      <ImageListSlider
+        ref={imageListSliderRef}
+        width={`${imageCount.current * 100}%`}
+        onWheel={onImageListSliderScroll}
+      >
+        {imageUrls.map((imageUrl, index) => (
+          <ImageList key={imageUrl}>
+            <img src={imageUrl} alt={`${index}번째 사진`} width="100%" />
+          </ImageList>
+        ))}
+      </ImageListSlider>
+      {!isFirstImage && (
+        <SlideButton type="button" onClick={onBackButtonClick} direction="left">
+          <GoBackIcon color={theme.color.white} />
+        </SlideButton>
+      )}
+      {!isLastImage && (
+        <SlideButton type="button" onClick={onForwardButtonClick} direction="right">
+          <GoForwardIcon color={theme.color.white} />
+        </SlideButton>
+      )}
+    </Container>
+  );
+};
+
+export default ImageSlider;

--- a/frontend/src/services/hooks/@common/useThrottle.ts
+++ b/frontend/src/services/hooks/@common/useThrottle.ts
@@ -1,0 +1,17 @@
+import { useRef } from "react";
+
+const useThrottle = (callback: (...args: any[]) => void, delay: number) => {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return (...args: any[]) => {
+    if (timer.current) return;
+
+    timer.current = setTimeout(() => {
+      timer.current = null;
+    }, delay);
+
+    callback(...args);
+  };
+};
+
+export default useThrottle;


### PR DESCRIPTION
## 상세 내용
- 이미지를 순서대로 정렬
- 전체 slider의 height는 가장 height가 큰 이미지를 기준으로한다.
- slider의 height보다 작은 이미지의 상하 공백은 검은 배경으로 채운다.
- 버튼 및 좌우 스크롤을 통해 슬라이드 할 수 있다.

## 기타
- useTrottle 추가
- goBack, goForward svg가 currentColor를 받도록 수정
