### PR TITLE
[#76] 로그인 기능 리팩토링 및 테스트 추가

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/JwtTokenProvider.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/JwtTokenProvider.java
@@ -9,4 +9,6 @@ public interface JwtTokenProvider {
     boolean validateToken(String token);
 
     String getPayloadByKey(String token, String key);
+
+    void changeExpirationTime(long expirationTimeInMilliSeconds);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
@@ -2,6 +2,7 @@ package com.woowacourse.pickgit.authentication.application;
 
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
+import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
@@ -17,12 +18,12 @@ public class OAuthService {
 
     private OAuthClient githubOAuthClient;
     private JwtTokenProvider jwtTokenProvider;
-    private CollectionOAuthAccessTokenDao authAccessTokenDao;
+    private OAuthAccessTokenDao authAccessTokenDao;
     private UserRepository userRepository;
 
     public OAuthService(OAuthClient githubOAuthClient,
         JwtTokenProvider jwtTokenProvider,
-        CollectionOAuthAccessTokenDao authAccessTokenDao,
+        OAuthAccessTokenDao authAccessTokenDao,
         UserRepository userRepository) {
         this.githubOAuthClient = githubOAuthClient;
         this.jwtTokenProvider = jwtTokenProvider;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/OAuthProfileResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/OAuthProfileResponse.java
@@ -28,6 +28,21 @@ public class OAuthProfileResponse {
     @JsonProperty("twitter_username")
     private String twitter;
 
+    public OAuthProfileResponse() {
+    }
+
+    public OAuthProfileResponse(String name, String image, String description,
+        String githubUrl, String company, String location, String website, String twitter) {
+        this.name = name;
+        this.image = image;
+        this.description = description;
+        this.githubUrl = githubUrl;
+        this.company = company;
+        this.location = location;
+        this.website = website;
+        this.twitter = twitter;
+    }
+
     public String getName() {
         return name;
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/JwtTokenProviderImpl.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/JwtTokenProviderImpl.java
@@ -52,7 +52,11 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 
     @Override
     public String getPayloadByKey(String token, String key) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get(key, String.class);
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get(key, String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
     }
 
     @Override

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/JwtTokenProviderImpl.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/JwtTokenProviderImpl.java
@@ -18,6 +18,14 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
     @Value("${security.jwt.expiration-time}")
     private long expirationTimeInMilliSeconds;
 
+    public JwtTokenProviderImpl() {
+    }
+
+    public JwtTokenProviderImpl(String secretKey, long expirationTimeInMilliSeconds) {
+        this.secretKey = secretKey;
+        this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;
+    }
+
     @Override
     public String createToken(String payload) {
         Date now = new Date();
@@ -45,5 +53,10 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
     @Override
     public String getPayloadByKey(String token, String key) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get(key, String.class);
+    }
+
+    @Override
+    public void changeExpirationTime(long expirationTimeInMilliSeconds) {
+        this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
@@ -3,10 +3,12 @@ package com.woowacourse.pickgit.authentication.presentation;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 public class OAuthController {
 
     private OAuthService oauthService;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
@@ -1,6 +1,8 @@
 package com.woowacourse.pickgit.authentication.presentation;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthLoginUrlResponse;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +20,12 @@ public class OAuthController {
     }
 
     @GetMapping("/authorization/github")
-    public ResponseEntity<String> githubAuthorizationUrl() {
-        return ResponseEntity.ok().body(oauthService.getGithubAuthorizationUrl());
+    public ResponseEntity<OAuthLoginUrlResponse> githubAuthorizationUrl() {
+        return ResponseEntity.ok().body(new OAuthLoginUrlResponse(oauthService.getGithubAuthorizationUrl()));
     }
 
     @GetMapping("/afterlogin")
-    public ResponseEntity<String> afterAuthorizeGithubLogin(@RequestParam String code) {
-        return ResponseEntity.ok().body(oauthService.createToken(code));
+    public ResponseEntity<OAuthTokenResponse> afterAuthorizeGithubLogin(@RequestParam String code) {
+        return ResponseEntity.ok().body(new OAuthTokenResponse(oauthService.createToken(code)));
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/dto/OAuthLoginUrlResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/dto/OAuthLoginUrlResponse.java
@@ -1,0 +1,21 @@
+package com.woowacourse.pickgit.authentication.presentation.dto;
+
+public class OAuthLoginUrlResponse {
+
+    private String url;
+
+    public OAuthLoginUrlResponse() {
+    }
+
+    public OAuthLoginUrlResponse(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/dto/OAuthTokenResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/dto/OAuthTokenResponse.java
@@ -1,0 +1,21 @@
+package com.woowacourse.pickgit.authentication.presentation.dto;
+
+public class OAuthTokenResponse {
+
+    private String token;
+
+    public OAuthTokenResponse() {
+    }
+
+    public OAuthTokenResponse(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
@@ -1,0 +1,53 @@
+package com.woowacourse.pickgit.authentication.presentation.interceptor;
+
+import com.woowacourse.pickgit.authentication.infrastructure.AuthorizationExtractor;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class IgnoreAuthenticationInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
+        if (isPreflightRequest(request)) {
+            return true;
+        }
+        if (isGetRequest(request)) {
+            throw new IllegalArgumentException("get 요청일 때만 가능");
+        }
+
+        String authentication = AuthorizationExtractor.extract(request);
+        if (authentication != null) {
+            request.setAttribute("authentication", authentication);
+        }
+        return true;
+    }
+
+    private boolean isPreflightRequest(HttpServletRequest request) {
+        return isOptions(request) && hasAccessControlRequestHeaders(request) && hasAccessControlRequestMethod(request)
+            && hasOrigin(request);
+    }
+
+    private boolean isOptions(HttpServletRequest request) {
+        return request.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS.toString());
+    }
+
+    private boolean hasAccessControlRequestHeaders(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader("Access-Control-Request-Headers"));
+    }
+
+    private boolean hasAccessControlRequestMethod(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader("Access-Control-Request-Method"));
+    }
+
+    private boolean hasOrigin(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader("Origin"));
+    }
+
+    private boolean isGetRequest(HttpServletRequest request) {
+        return request.getMethod().equals(HttpMethod.GET.name());
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -3,6 +3,7 @@ package com.woowacourse.pickgit.config;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.presentation.AuthenticationPrincipalArgumentResolver;
 import com.woowacourse.pickgit.authentication.presentation.interceptor.AuthenticationInterceptor;
+import com.woowacourse.pickgit.authentication.presentation.interceptor.IgnoreAuthenticationInterceptor;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +27,11 @@ public class OAuthConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
+    public IgnoreAuthenticationInterceptor ignoreAuthenticationInterceptor() {
+        return new IgnoreAuthenticationInterceptor();
+    }
+
+    @Bean
     public AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
         return new AuthenticationPrincipalArgumentResolver(oAuthService);
     }
@@ -38,8 +44,13 @@ public class OAuthConfiguration implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor())
-            .addPathPatterns("/api/**")
+            .addPathPatterns("/api/profiles/me")
+            .addPathPatterns("/api/posts/me")
             .excludePathPatterns("/api/authorization/github")
             .excludePathPatterns("/api/afterlogin");
+
+        registry.addInterceptor(ignoreAuthenticationInterceptor())
+            .addPathPatterns("/api/profiles/*")
+            .addPathPatterns("/api/posts/*");
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -38,7 +38,8 @@ public class OAuthConfiguration implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor())
-            .excludePathPatterns("/authorization/github")
-            .excludePathPatterns("/afterlogin");
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/authorization/github")
+            .excludePathPatterns("/api/afterlogin");
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -54,4 +54,12 @@ public class User {
 
     public void unfollow(User target) {
     }
+
+    public BasicProfile getBasicProfile() {
+        return basicProfile;
+    }
+
+    public GithubProfile getGithubProfile() {
+        return githubProfile;
+    }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/BasicProfile.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/BasicProfile.java
@@ -21,4 +21,8 @@ public class BasicProfile {
         this.image = image;
         this.description = description;
     }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/GithubProfile.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/GithubProfile.java
@@ -28,4 +28,12 @@ public class GithubProfile {
         this.website = website;
         this.twitter = twitter;
     }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public String getGithubUrl() {
+        return githubUrl;
+    }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
@@ -1,0 +1,88 @@
+package com.woowacourse.pickgit.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.domain.OAuthClient;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthLoginUrlResponse;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+public class OAuthAcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @MockBean
+    private OAuthClient oAuthClient;
+
+    @DisplayName("로그인 - Github OAuth 로그인 URL을 요청한다.")
+    @Test
+    void Authorization_Github_ReturnLoginUrl() {
+        // when
+        OAuthLoginUrlResponse response = RestAssured
+            .given().log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/authorization/github")
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract().as(OAuthLoginUrlResponse.class);
+
+        // then
+        assertThat(
+            response.getUrl().startsWith("https://github.com/login/oauth/authorize")
+        ).isTrue();
+    }
+
+    @DisplayName("로그인 - Github 인증후 리다이렉션을 통해 요청이 오면 토큰을 생성하여 반환한다.")
+    @Test
+    void Authorization_Redirection_ReturnJwtToken() {
+        // given
+        String oauthCode = "1234";
+        String accessToken = "oauth.access.token";
+
+        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
+            "pick-git", "image", "hi~", "github.com/",
+            null, null, null, null
+        );
+
+        // mock
+        when(oAuthClient.getAccessToken(oauthCode)).thenReturn(accessToken);
+        when(oAuthClient.getGithubProfile(accessToken)).thenReturn(oAuthProfileResponse);
+
+        // when
+        OAuthTokenResponse response = RestAssured
+            .given().log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/afterlogin?code=" + oauthCode)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract().as(OAuthTokenResponse.class);
+
+        // then
+        assertThat(response.getToken()).isNotBlank();
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
@@ -8,6 +8,8 @@ import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthLoginUrlResponse;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,19 @@ public class OAuthAcceptanceTest {
     @DisplayName("로그인 - Github 인증후 리다이렉션을 통해 요청이 오면 토큰을 생성하여 반환한다.")
     @Test
     void Authorization_Redirection_ReturnJwtToken() {
+        // then
+        String token = 로그인_되어있음().getToken();
+
+        System.out.println(token);
+    }
+
+    public OAuthTokenResponse 로그인_되어있음() {
+        OAuthTokenResponse response = 로그인_요청().as(OAuthTokenResponse.class);
+        assertThat(response.getToken()).isNotBlank();
+        return response;
+    }
+
+    public ExtractableResponse<Response> 로그인_요청() {
         // given
         String oauthCode = "1234";
         String accessToken = "oauth.access.token";
@@ -76,16 +91,13 @@ public class OAuthAcceptanceTest {
         when(oAuthClient.getGithubProfile(accessToken)).thenReturn(oAuthProfileResponse);
 
         // when
-        OAuthTokenResponse response = RestAssured
+        return RestAssured
             .given().log().all()
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .when()
             .get("/api/afterlogin?code=" + oauthCode)
             .then().log().all()
             .statusCode(HttpStatus.OK.value())
-            .extract().as(OAuthTokenResponse.class);
-
-        // then
-        assertThat(response.getToken()).isNotBlank();
+            .extract();
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
@@ -40,6 +40,9 @@ public class OAuthAcceptanceTest {
     @DisplayName("로그인 - Github OAuth 로그인 URL을 요청한다.")
     @Test
     void Authorization_Github_ReturnLoginUrl() {
+        // mock
+        when(oAuthClient.getLoginUrl()).thenReturn("https://github.com/login/oauth/authorize?");
+
         // when
         OAuthLoginUrlResponse response = RestAssured
             .given().log().all()
@@ -64,7 +67,7 @@ public class OAuthAcceptanceTest {
         String accessToken = "oauth.access.token";
 
         OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
-            "pick-git", "image", "hi~", "github.com/",
+            "pick-git-login", "image", "hi~", "github.com/",
             null, null, null, null
         );
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
@@ -1,0 +1,125 @@
+package com.woowacourse.pickgit.authentication.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
+import com.woowacourse.pickgit.authentication.domain.OAuthClient;
+import com.woowacourse.pickgit.user.domain.User;
+import com.woowacourse.pickgit.user.domain.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("OAuthService Mock 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class OAuthServiceMockTest {
+
+    @Mock
+    private OAuthClient oAuthClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CollectionOAuthAccessTokenDao oAuthAccessTokenDao;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private OAuthService oAuthService;
+
+    @DisplayName("Github 로그인 URL을 반환한다.")
+    @Test
+    void getGithubAuthorizationUrl_Anonymous_ReturnGithubAuthorizationUrl() {
+        // given
+        String url = "https://github.com/login..";
+
+        // mock
+        when(oAuthClient.getLoginUrl()).thenReturn(url);
+
+        // then
+        assertThat(oAuthService.getGithubAuthorizationUrl()).isEqualTo(url);
+    }
+
+    @DisplayName("회원가입(첫 로그인)시 Github Profile을 가져와서 DB에 insert한다.")
+    @Test
+    void createToken_Signup_SaveUserProfile() {
+        // given
+        String code = "oauth authorization code";
+        String oauthAccessToken = "oauth access token";
+        String jwtToken = "jwt token";
+
+        OAuthProfileResponse githubProfileResponse = new OAuthProfileResponse();
+        githubProfileResponse.setName("test");
+        githubProfileResponse.setDescription("hi~");
+
+        User user = new User(
+            githubProfileResponse.toBasicProfile(),
+            githubProfileResponse.toGithubProfile()
+        );
+
+        // mock
+        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
+        when(oAuthClient.getGithubProfile(oauthAccessToken)).thenReturn(githubProfileResponse);
+        when(userRepository.findByBasicProfile_Name(githubProfileResponse.getName())).thenReturn(
+            Optional.empty());
+        when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
+
+        // when
+        String token = oAuthService.createToken(code);
+
+        // then
+        assertThat(token).isEqualTo(jwtToken);
+        verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
+        verify(userRepository, never()).save(user);
+        verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
+        verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
+    }
+
+    @DisplayName("로그인(첫 로그인이 아닌경우)시 Github Profile을 가져와서 DB에 저장된 기존 정보를 update한다.")
+    @Test
+    void createToken_Signup_UpdateUserProfile() {
+        // given
+        String code = "oauth authorization code";
+        String oauthAccessToken = "oauth access token";
+        String jwtToken = "jwt token";
+
+        OAuthProfileResponse githubProfileResponse = new OAuthProfileResponse();
+        githubProfileResponse.setName("test");
+        githubProfileResponse.setDescription("hi~");
+
+        User user = new User(
+            githubProfileResponse.toBasicProfile(),
+            githubProfileResponse.toGithubProfile()
+        );
+
+        // mock
+        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
+        when(oAuthClient.getGithubProfile(oauthAccessToken)).thenReturn(githubProfileResponse);
+        when(userRepository.findByBasicProfile_Name(githubProfileResponse.getName())).thenReturn(
+            Optional.of(user));
+        when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
+
+        // when
+        String token = oAuthService.createToken(code);
+
+        // then
+        assertThat(token).isEqualTo(jwtToken);
+        verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
+        verify(userRepository, times(1)).save(user);
+        verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
+        verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
@@ -1,10 +1,14 @@
 package com.woowacourse.pickgit.authentication.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
+import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -15,13 +19,19 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
-@DisplayName("OAuthService 통합 테스트 (UserService 사용)")
+@DisplayName("OAuthService 통합 테스트 (UserRepository 사용)")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
 public class OAuthServiceTest {
 
     @MockBean
     private OAuthClient oAuthClient;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private OAuthAccessTokenDao oAuthAccessTokenDao;
 
     @Autowired
     private UserRepository userRepository;
@@ -94,5 +104,36 @@ public class OAuthServiceTest {
         User user = userRepository.findByBasicProfile_Name(oAuthProfileResponse.getName()).orElse(null);
         assertThat(user).isNotNull();
         assertThat(user.getGithubProfile().getCompany()).isEqualTo("@woowabros");
+    }
+
+    @DisplayName("JWT 토큰을 통해 AccessTokenDB에서 LoginUser에 대한 정보를 가져온다.")
+    @Test
+    void findRequestUserByToken_ValidToken_ReturnAppUser() {
+        // given
+        String username = "pick-git";
+        String token = jwtTokenProvider.createToken(username);
+        String accessToken = "oauth access token";
+
+        oAuthAccessTokenDao.insert(token, accessToken);
+
+        // when
+        AppUser appUser = oAuthService.findRequestUserByToken(token);
+
+        // then
+        assertThat(appUser).isInstanceOf(LoginUser.class);
+        assertThat(appUser.getUsername()).isEqualTo(username);
+        assertThat(appUser.getAccessToken()).isEqualTo(accessToken);
+    }
+
+    @DisplayName("AccessTokenDB에 저장되어 있지 않은 JWT 토큰이라면 예외가 발생한다.")
+    @Test
+    void findRequestUserByToken_NotFoundToken_ThrowException() {
+        // given
+        String username = "pick-git";
+        String token = jwtTokenProvider.createToken(username);
+
+        // when, then
+        assertThatThrownBy(() -> oAuthService.findRequestUserByToken(token))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
-import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
@@ -16,55 +15,84 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
-@DisplayName("OAuthService 단위 테스트 - ")
+@DisplayName("OAuthService 통합 테스트 (UserService 사용)")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
-class OAuthServiceTest {
-
-    @Autowired
-    private OAuthService oAuthService;
+public class OAuthServiceTest {
 
     @MockBean
     private OAuthClient oAuthClient;
 
-    @MockBean
+    @Autowired
     private UserRepository userRepository;
 
-    @MockBean
-    private CollectionOAuthAccessTokenDao oAuthAccessTokenDao;
+    @Autowired
+    private OAuthService oAuthService;
 
     @DisplayName("Github 로그인 URL을 반환한다.")
     @Test
     void getGithubAuthorizationUrl_Anonymous_ReturnGithubAuthorizationUrl() {
-        // given
-        String url = "https://github.com/login..";
-
         // mock
-        when(oAuthClient.getLoginUrl()).thenReturn(url);
+        when(oAuthClient.getLoginUrl()).thenReturn("https://github.com/login/oauth/authorize?");
+
+        // when
+        String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
 
         // then
-        assertThat(oAuthService.getGithubAuthorizationUrl()).isEqualTo(url);
+        assertThat(githubAuthorizationUrl).startsWith("https://github.com/login/oauth/authorize?");
     }
 
-    @DisplayName("회원가입(첫 로그인)시 Github Profile을 가져와서 DB에 저장한다.")
+    @DisplayName("회원가입(첫 로그인)시 Github Profile을 가져와서 DB에 insert한다.")
     @Test
     void createToken_Signup_SaveUserProfile() {
         // given
         String code = "oauth authorization code";
         String oauthAccessToken = "oauth access token";
-
-        OAuthProfileResponse githubProfileResponse = new OAuthProfileResponse();
-        githubProfileResponse.setName("test");
-        githubProfileResponse.setDescription("hi~");
-
-        User user = new User(
-            githubProfileResponse.toBasicProfile(),
-            githubProfileResponse.toGithubProfile()
+        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
+            "binghe", "image", null, "github.com/",
+            null, null, null, null
         );
 
         // mock
         when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
-        when(oAuthClient.getGithubProfile(oauthAccessToken)).thenReturn(githubProfileResponse);
+        when(oAuthClient.getGithubProfile(oauthAccessToken))
+            .thenReturn(oAuthProfileResponse);
 
+        // when
+        oAuthService.createToken(code);
+
+        // then
+        User user = userRepository.findByBasicProfile_Name(oAuthProfileResponse.getName()).orElse(null);
+        assertThat(user).isNotNull();
+        assertThat(user.getBasicProfile().getName()).isEqualTo("binghe");
+        assertThat(user.getGithubProfile().getGithubUrl()).isEqualTo("github.com/");
+    }
+
+    @DisplayName("로그인(첫 로그인이 아닌경우)시 Github Profile을 가져와서 DB에 저장된 기존 정보를 update한다.")
+    @Test
+    void createToken_Signup_UpdateUserProfile() {
+        // given
+        String code = "oauth authorization code";
+        String oauthAccessToken = "oauth access token";
+        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
+            "binghe", "image", null, "github.com/",
+            null, null, null, null
+        );
+
+        // mock
+        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
+        when(oAuthClient.getGithubProfile(oauthAccessToken))
+            .thenReturn(oAuthProfileResponse);
+
+        // when
+        oAuthService.createToken(code);
+
+        oAuthProfileResponse.setCompany("@woowabros");
+        oAuthService.createToken(code);
+
+        // then
+        User user = userRepository.findByBasicProfile_Name(oAuthProfileResponse.getName()).orElse(null);
+        assertThat(user).isNotNull();
+        assertThat(user.getGithubProfile().getCompany()).isEqualTo("@woowabros");
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
@@ -129,7 +129,7 @@ public class OAuthServiceTest {
     @Test
     void findRequestUserByToken_NotFoundToken_ThrowException() {
         // given
-        String username = "pick-git";
+        String username = "pick-git-test";
         String token = jwtTokenProvider.createToken(username);
 
         // when, then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolverTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolverTest.java
@@ -1,0 +1,113 @@
+package com.woowacourse.pickgit.authentication.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
+import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
+import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
+import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.context.request.ServletWebRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationPrincipalArgumentResolverTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private OAuthAccessTokenDao oAuthAccessTokenDao;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @InjectMocks
+    private OAuthService oAuthService;
+
+    private AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProviderImpl("pick-git", 3600000);
+        oAuthAccessTokenDao = new CollectionOAuthAccessTokenDao();
+        oAuthService = new OAuthService(null, jwtTokenProvider, oAuthAccessTokenDao, null);
+        authenticationPrincipalArgumentResolver = new AuthenticationPrincipalArgumentResolver(oAuthService);
+    }
+
+    @DisplayName("유효한 토큰이면 LoginUser를 반환한다.")
+    @Test
+    void resolveArgument_ValidUserToken_ReturnLoginUser() throws Exception {
+        // given
+        String username = "pick-git";
+        String accessToken = "oauth access token";
+        String jwtToken = jwtTokenProvider.createToken(username);
+
+        oAuthAccessTokenDao.insert(jwtToken, accessToken);
+
+        // mock
+        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+
+        // when
+        AppUser loginUser = (AppUser) authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
+
+        // then
+        assertThat(loginUser.isGuest()).isFalse();
+        assertThat(loginUser.getUsername()).isEqualTo(username);
+        assertThat(loginUser.getAccessToken()).isEqualTo(accessToken);
+    }
+
+    @DisplayName("유효하지 않은 토큰이면 예외가 발생한다.")
+    @Test
+    void resolveArgument_InvalidToken_ThrowException() throws Exception {
+        // given
+        String jwtToken = "invalid jwt token";
+
+        // mock
+        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+
+        // then
+        assertThatThrownBy(() -> {
+            authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("AccessToken DB에 저장되어 있지 않은 토큰이라면 예외가 발생한다.")
+    @Test
+    void resolveArgument_NotFoundToken_ThrowException() {
+        // given
+        String jwtToken = jwtTokenProvider.createToken("pick-git");
+
+        // when
+        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+
+        assertThatThrownBy(() -> {
+            authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("요청 헤더에 authorization을 추가해주지 않으면 Guest가 반환된다.")
+    @Test
+    void resolveArgument_InValidUserToken_ReturnGuest() throws Exception {
+        // mock
+        when(httpServletRequest.getAttribute("authentication")).thenReturn(null);
+
+        // when
+        AppUser loginUser = (AppUser) authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
+
+        // then
+        assertThat(loginUser.isGuest()).isTrue();
+        assertThatThrownBy(() -> loginUser.getAccessToken())
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> loginUser.getUsername())
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(OAuthController.class)
 @ActiveProfiles("test")
 class OAuthControllerTest {
@@ -35,7 +34,7 @@ class OAuthControllerTest {
         when(oAuthService.getGithubAuthorizationUrl()).thenReturn(githubAuthorizationGithubUrl);
 
         // when, then
-        mockMvc.perform(get("/authorization/github"))
+        mockMvc.perform(get("/api/authorization/github"))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(content().string(githubAuthorizationGithubUrl));
@@ -49,7 +48,7 @@ class OAuthControllerTest {
         when(oAuthService.createToken(githubAuthorizationCode)).thenReturn("jwt token");
 
         // when, then
-        mockMvc.perform(get("/afterlogin?code=" + githubAuthorizationCode))
+        mockMvc.perform(get("/api/afterlogin?code=" + githubAuthorizationCode))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(content().string("jwt token"));

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest
+@WebMvcTest(OAuthController.class)
 @ActiveProfiles("test")
 class OAuthControllerTest {
     @Autowired

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
@@ -37,7 +38,7 @@ class OAuthControllerTest {
         mockMvc.perform(get("/api/authorization/github"))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(content().string(githubAuthorizationGithubUrl));
+            .andExpect(jsonPath("url").value(githubAuthorizationGithubUrl));
     }
 
     @DisplayName("Github 로그인 인증 후 토큰을 발행하여 반환한다.")
@@ -51,6 +52,6 @@ class OAuthControllerTest {
         mockMvc.perform(get("/api/afterlogin?code=" + githubAuthorizationCode))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(content().string("jwt token"));
+            .andExpect(jsonPath("token").value("jwt token"));
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptorTest.java
@@ -1,0 +1,107 @@
+package com.woowacourse.pickgit.authentication.presentation.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
+import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.infrastructure.AuthorizationExtractor;
+import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationInterceptorTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private OAuthService oAuthService;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @InjectMocks
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProviderImpl("pick-git", 3600000);
+        oAuthService = new OAuthService(null, jwtTokenProvider, null, null);
+        authenticationInterceptor = new AuthenticationInterceptor(oAuthService);
+    }
+
+    @DisplayName("CORS 프리플라이트 요청이면 true를 반환한다.")
+    @Test
+    void preHandle_CORS_True() throws Exception {
+        // mock
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
+        when(httpServletRequest.getHeader("Access-Control-Request-Headers")).thenReturn("X-PINGOTHER, Content-Type");
+        when(httpServletRequest.getHeader("Access-Control-Request-Method")).thenReturn("POST");
+        when(httpServletRequest.getHeader("Origin")).thenReturn("http://pick-git.example");
+
+        // then
+        assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
+    }
+
+    @DisplayName("유효한 토큰의 요청이면 HttpServletRequest에 토큰 정보를 저장하고 true를 반환한다.")
+    @Test
+    void preHandle_ValidToken_True() throws Exception {
+        // given
+        String validToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
+
+        // mock, when
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
+        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION)).thenReturn(Collections.enumeration(
+            List.of(validToken)));
+
+        // then
+        assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
+        verify(httpServletRequest, times(2)).setAttribute(any(String.class), any(String.class));
+    }
+
+    @DisplayName("유효하지 않은 토큰의 요청이면 예외를 던진다.")
+    @Test
+    void preHandle_InvalidToken_ThrowException() {
+        // given
+        String bearerToken = "Bearer " + "invalid token";
+
+        // mock
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
+        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION)).thenReturn(Collections.enumeration(
+            List.of(bearerToken)));
+
+        // when, then
+        assertThatThrownBy(() -> authenticationInterceptor.preHandle(httpServletRequest, null, null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("유효기간이 지난 토큰의 경우 예외가 발생한다.")
+    @Test
+    void preHandle_ExpiredToken_ThrowException() {
+        // given
+        jwtTokenProvider.changeExpirationTime(0);
+        String bearerToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
+
+        // mock
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
+        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION)).thenReturn(Collections.enumeration(
+            List.of(bearerToken)));
+
+        // when, then
+        assertThatThrownBy(() -> authenticationInterceptor.preHandle(httpServletRequest, null, null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 상세 내용
* 리팩토링 내용
  * URL앞에 `/api` 추가
  * 로그인 관련 요청 반환값으로 json 형식이 반환되도록 리팩토링
* 테스트 추가
  * 슬라이스 테스트
  * 통합 테스트
  * OAuth Access Token 저장소 테스트
  * 인수테스트 완성되는대로 커밋할게유~
* 추가 고려사항
  * 예외처리 전략에 따라 커스텀 예외 적용

<br>

## 기타
* 테스트가 원활하게 돌아가려면 `test` yml 파일을 설정해주어야 합니다! 슬랙에 있는 것을 참고하세유

<br>

## ps. 리팩토링했으면 하는 부분이나 테스트 추가했으면 하는 부분있으면 알려주세요~