### PR TITLE
[#113] 프로필 조회시 팔로우 여부 기능 구현

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
@@ -12,6 +12,7 @@ import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.domain.profile.BasicProfile;
 import com.woowacourse.pickgit.user.domain.profile.GithubProfile;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class OAuthService {
@@ -35,6 +36,7 @@ public class OAuthService {
         return githubOAuthClient.getLoginUrl();
     }
 
+    @Transactional
     public String createToken(String code) {
         String githubAccessToken = githubOAuthClient.getAccessToken(code);
 
@@ -51,7 +53,6 @@ public class OAuthService {
         userRepository.findByBasicProfile_Name(githubProfileResponse.getName())
             .ifPresentOrElse(user -> {
                 user.changeGithubProfile(latestGithubProfile);
-                userRepository.save(user);
             }, () -> {
                 BasicProfile basicProfile = githubProfileResponse.toBasicProfile();
                 User user = new User(basicProfile, latestGithubProfile);
@@ -65,6 +66,7 @@ public class OAuthService {
         return token;
     }
 
+    @Transactional(readOnly = true)
     public AppUser findRequestUserByToken(String authentication) {
         if (authentication == null) {
             return new GuestUser();

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pickgit.user.application;
 
+import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.user.application.dto.AuthUserServiceDto;
 import com.woowacourse.pickgit.user.application.dto.FollowServiceDto;
 import com.woowacourse.pickgit.user.application.dto.UserProfileServiceDto;
@@ -22,19 +23,37 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserProfileServiceDto getAuthUserProfile(AuthUserServiceDto authUserServiceDto) {
-        return getUserProfile(authUserServiceDto.getGithubName());
-    }
-
-    @Transactional(readOnly = true)
-    public UserProfileServiceDto getUserProfile(String username) {
-        User user = findUserByName(username);
+    public UserProfileServiceDto getMyUserProfile(AuthUserServiceDto authUserServiceDto) {
+        User user = findUserByName(authUserServiceDto.getGithubName());
 
         return new UserProfileServiceDto(
             user.getName(), user.getImage(), user.getDescription(),
             user.getFollowerCount(), user.getFollowingCount(), user.getPostCount(),
             user.getGithubUrl(), user.getCompany(), user.getLocation(),
-            user.getWebsite(), user.getTwitter()
+            user.getWebsite(), user.getTwitter(), null
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileServiceDto getUserProfile(AppUser appUser, String targetUsername) {
+        User targetUser = findUserByName(targetUsername);
+
+        if (appUser.isGuest()) {
+            return new UserProfileServiceDto(
+                targetUser.getName(), targetUser.getImage(), targetUser.getDescription(),
+                targetUser.getFollowerCount(), targetUser.getFollowingCount(), targetUser.getPostCount(),
+                targetUser.getGithubUrl(), targetUser.getCompany(), targetUser.getLocation(),
+                targetUser.getWebsite(), targetUser.getTwitter(), null
+            );
+        }
+
+        User sourceUser = findUserByName(appUser.getUsername());
+
+        return new UserProfileServiceDto(
+            targetUser.getName(), targetUser.getImage(), targetUser.getDescription(),
+            targetUser.getFollowerCount(), targetUser.getFollowingCount(), targetUser.getPostCount(),
+            targetUser.getGithubUrl(), targetUser.getCompany(), targetUser.getLocation(),
+            targetUser.getWebsite(), targetUser.getTwitter(), sourceUser.isFollowing(targetUser)
         );
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/UserProfileServiceDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/UserProfileServiceDto.java
@@ -16,9 +16,11 @@ public class UserProfileServiceDto {
     private final String website;
     private final String twitter;
 
+    private final Boolean following;
+
     public UserProfileServiceDto(String name, String image, String description,
         int followerCount, int followingCount, int postCount, String githubUrl, String company,
-        String location, String website, String twitter) {
+        String location, String website, String twitter, Boolean following) {
         this.name = name;
         this.image = image;
         this.description = description;
@@ -30,6 +32,7 @@ public class UserProfileServiceDto {
         this.location = location;
         this.website = website;
         this.twitter = twitter;
+        this.following = following;
     }
 
     public String getName() {
@@ -74,5 +77,9 @@ public class UserProfileServiceDto {
 
     public String getTwitter() {
         return twitter;
+    }
+
+    public Boolean getFollowing() {
+        return following;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -10,6 +10,7 @@ import com.woowacourse.pickgit.user.domain.profile.BasicProfile;
 import com.woowacourse.pickgit.user.domain.profile.GithubProfile;
 import com.woowacourse.pickgit.user.exception.DuplicatedFollowException;
 import com.woowacourse.pickgit.user.exception.InvalidFollowException;
+import java.util.Objects;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -83,6 +84,10 @@ public class User {
         target.followers.remove(follow);
     }
 
+    public Boolean isFollowing(User targetUser) {
+        return this.followings.isFollowing(targetUser);
+    }
+
     public int getFollowerCount() {
         return followers.count();
     }
@@ -143,5 +148,22 @@ public class User {
         comment.toPost(post)
             .writeBy(this);
         post.addComment(comment);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/follow/Followings.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/follow/Followings.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pickgit.user.domain.follow;
 
+import com.woowacourse.pickgit.user.domain.User;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -30,6 +31,12 @@ public class Followings {
 
     public void remove(Follow follow) {
         followings.remove(follow);
+    }
+
+    public Boolean isFollowing(User targetUser) {
+        return followings.stream()
+            .filter(follow -> follow.getTarget().equals(targetUser))
+            .findAny().isPresent();
     }
 }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserProfileResponseDto> getAuthenticatedUserProfile(
         @Authenticated AppUser appUser) {
-        UserProfileServiceDto userProfileServiceDto = userService.getAuthUserProfile(
+        UserProfileServiceDto userProfileServiceDto = userService.getMyUserProfile(
             new AuthUserServiceDto(appUser.getUsername())
         );
 
@@ -37,8 +37,9 @@ public class UserController {
     }
 
     @GetMapping("/{username}")
-    public ResponseEntity<UserProfileResponseDto> getUserProfile(@PathVariable String username) {
-        UserProfileServiceDto userProfileServiceDto = userService.getUserProfile(username);
+    public ResponseEntity<UserProfileResponseDto> getUserProfile(
+        @Authenticated AppUser appUser, @PathVariable String username) {
+        UserProfileServiceDto userProfileServiceDto = userService.getUserProfile(appUser, username);
 
         return ResponseEntity.ok(getUserProfileResponseDto(userProfileServiceDto));
     }
@@ -77,7 +78,7 @@ public class UserController {
             userProfileServiceDto.getFollowingCount(), userProfileServiceDto.getPostCount(),
             userProfileServiceDto.getGithubUrl(), userProfileServiceDto.getCompany(),
             userProfileServiceDto.getLocation(), userProfileServiceDto.getWebsite(),
-            userProfileServiceDto.getTwitter()
+            userProfileServiceDto.getTwitter(), userProfileServiceDto.getFollowing()
         );
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/UserProfileResponseDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/UserProfileResponseDto.java
@@ -16,12 +16,14 @@ public class UserProfileResponseDto {
     private String website;
     private String twitter;
 
+    private Boolean following;
+
     private UserProfileResponseDto() {
     }
 
     public UserProfileResponseDto(String name, String image, String description, int followerCount,
         int followingCount, int postCount, String githubUrl, String company, String location,
-        String website, String twitter) {
+        String website, String twitter, Boolean following) {
         this.name = name;
         this.image = image;
         this.description = description;
@@ -33,6 +35,7 @@ public class UserProfileResponseDto {
         this.location = location;
         this.website = website;
         this.twitter = twitter;
+        this.following = following;
     }
 
     public String getName() {
@@ -77,5 +80,9 @@ public class UserProfileResponseDto {
 
     public String getTwitter() {
         return twitter;
+    }
+
+    public Boolean getFollowing() {
+        return following;
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
@@ -87,7 +87,7 @@ class OAuthServiceMockTest {
         // then
         assertThat(token).isEqualTo(jwtToken);
         verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
-        verify(userRepository, never()).save(user);
+        verify(userRepository, times(1)).save(user);
         verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
         verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
     }
@@ -122,7 +122,7 @@ class OAuthServiceMockTest {
         // then
         assertThat(token).isEqualTo(jwtToken);
         verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
-        verify(userRepository, times(1)).save(user);
+        verify(userRepository, never()).save(user);
         verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
         verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/application/UserServiceMockTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/application/UserServiceMockTest.java
@@ -7,6 +7,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.user.UserFactory;
 import com.woowacourse.pickgit.user.application.dto.AuthUserServiceDto;
 import com.woowacourse.pickgit.user.application.dto.FollowServiceDto;
@@ -49,10 +51,17 @@ class UserServiceMockTest {
         this.userFactory = new UserFactory();
     }
 
+    @DisplayName("본인의 프로필 정보를 성공적으로 가져온다.")
+    @Test
+    void name() {
+
+    }
+
     @DisplayName("유저이름으로 검색한 User 기반으로 프로필 정보를 성공적으로 가져온다.")
     @Test
-    public void getUserProfile_FindUserInfoByName_Success() {
+    void getUserProfile_FindUserInfoByName_Success() {
         //given
+        AppUser appUser = new GuestUser();
         given(
             userRepository.findByBasicProfile_Name(anyString())
         ).willReturn(Optional.of(userFactory.user()));
@@ -60,11 +69,11 @@ class UserServiceMockTest {
         UserProfileServiceDto expectedUserProfileDto = new UserProfileServiceDto(
             NAME, IMAGE, DESCRIPTION,
             0, 0, 0,
-            GITHUB_URL, COMPANY, LOCATION, WEBSITE, TWITTER
+            GITHUB_URL, COMPANY, LOCATION, WEBSITE, TWITTER, null
         );
 
         //when
-        UserProfileServiceDto actualUserProfileDto = userService.getUserProfile(NAME);
+        UserProfileServiceDto actualUserProfileDto = userService.getUserProfile(appUser, NAME);
 
         //then
         assertThat(actualUserProfileDto)
@@ -78,10 +87,11 @@ class UserServiceMockTest {
     @Test
     void getUserProfile_FindUserInfoByInvalidName_Success() {
         //given
+        AppUser appUser = new GuestUser();
         //when
         //then
         assertThatThrownBy(
-            () -> userService.getUserProfile("InvalidName")
+            () -> userService.getUserProfile(appUser, "InvalidName")
         ).hasMessage(new InvalidUserException().getMessage());
 
         verify(userRepository, times(1)).findByBasicProfile_Name(anyString());

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/integration/UserIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/integration/UserIntegrationTest.java
@@ -74,7 +74,7 @@ public class UserIntegrationTest {
             new UserProfileResponseDto(user.getName(), user.getImage(), user.getDescription(),
                 user.getFollowerCount(), user.getFollowingCount(), user.getPostCount(),
                 user.getGithubUrl(), user.getCompany(), user.getLocation(), user.getWebsite(),
-                user.getTwitter());
+                user.getTwitter(), null);
 
         //when
         UserProfileResponseDto actualResponseDto =
@@ -98,17 +98,44 @@ public class UserIntegrationTest {
         unauthenticatedGetRequest(requestUrl, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @DisplayName("로그인 상태에서 타인의 프로필 조회에 성공한다.")
+    @DisplayName("로그인 상태에서 팔로우하는 타인의 프로필 조회에 성공한다.")
     @Test
-    void getUserProfile_ValidLoginUser_Success() {
+    void getUserProfile_ValidLoginUserFollowing_Success() {
         //given
-        User user = userFactory.user();
+        User targetUser = userFactory.anotherUser();
+
+        String followRequestUrl = "/api/profiles/" + targetUser.getName() + "/followings";
+        String requestUrl = "/api/profiles/" + targetUser.getName();
+        UserProfileResponseDto expectedResponseDto =
+            new UserProfileResponseDto(targetUser.getName(), targetUser.getImage(), targetUser.getDescription(),
+                1, targetUser.getFollowingCount(), targetUser.getPostCount(),
+                targetUser.getGithubUrl(), targetUser.getCompany(), targetUser.getLocation(), targetUser.getWebsite(),
+                targetUser.getTwitter(), true);
+
+        authenticatedPostRequest(userAccessToken, followRequestUrl, HttpStatus.OK);
+
+        //when
+        UserProfileResponseDto actualResponseDto =
+            authenticatedGetRequest(userAccessToken, requestUrl, HttpStatus.OK)
+                .as(UserProfileResponseDto.class);
+
+        //then
+        assertThat(actualResponseDto)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponseDto);
+    }
+
+    @DisplayName("로그인 상태에서 팔로우하지 않는 타인의 프로필 조회에 성공한다.")
+    @Test
+    void getUserProfile_ValidLoginUserUnfollowing_Success() {
+        //given
+        User user = userFactory.anotherUser();
         String requestUrl = "/api/profiles/" + user.getName();
         UserProfileResponseDto expectedResponseDto =
             new UserProfileResponseDto(user.getName(), user.getImage(), user.getDescription(),
                 user.getFollowerCount(), user.getFollowingCount(), user.getPostCount(),
                 user.getGithubUrl(), user.getCompany(), user.getLocation(), user.getWebsite(),
-                user.getTwitter());
+                user.getTwitter(), false);
 
         //when
         UserProfileResponseDto actualResponseDto =
@@ -131,7 +158,7 @@ public class UserIntegrationTest {
             new UserProfileResponseDto(user.getName(), user.getImage(), user.getDescription(),
                 user.getFollowerCount(), user.getFollowingCount(), user.getPostCount(),
                 user.getGithubUrl(), user.getCompany(), user.getLocation(), user.getWebsite(),
-                user.getTwitter());
+                user.getTwitter(), null);
 
         //when
         UserProfileResponseDto actualResponseDto =
@@ -143,8 +170,6 @@ public class UserIntegrationTest {
             .usingRecursiveComparison()
             .isEqualTo(expectedResponseDto);
     }
-
-    //TODO 내가 나를 팔로우/언팔로우 할 수 없음
 
     @DisplayName("한 로그인 유저가 다른 유저를 팔로우하는데 성공한다.")
     @Test


### PR DESCRIPTION
## 상세 내용
- 로그인 된 상태에서 본인 프로필 조회 시 `following` 데이터는 `null`로 반환 
- 비로그인 된 상태에서 타인의 프로필 조회 시 `following` 데이터는 `null`로 반환
- 로그인 된 상태에서 팔로우 중인 타인의 프로필 조회 시 `following` 데이터는 `true` 반환
- 로그인 된 상태에서 팔로우 중이 아닌 타인의 프로필 조회시 `following` 데이터는 `false` 반환