### PR TITLE
[hotfix] Post의 @DataJpaTest 테스트 실패 에러 복구

### DIFF
--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/TestJpaConfiguration.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/TestJpaConfiguration.java
@@ -1,0 +1,10 @@
+package com.woowacourse.pickgit;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfiguration {
+
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/domain/PostRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.pickgit.post.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.pickgit.TestJpaConfiguration;
 import com.woowacourse.pickgit.post.domain.comment.Comment;
 import com.woowacourse.pickgit.post.domain.comment.Comments;
 import com.woowacourse.pickgit.post.domain.content.Image;
@@ -11,6 +12,7 @@ import com.woowacourse.pickgit.tag.domain.TagRepository;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.profile.BasicProfile;
 import com.woowacourse.pickgit.user.domain.profile.GithubProfile;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +22,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
+@Import({TestJpaConfiguration.class})
 @DataJpaTest
 class PostRepositoryTest {
 
@@ -80,6 +84,20 @@ class PostRepositoryTest {
 
         // then
         assertThat(savedPost.getId()).isNotNull();
+    }
+
+    @DisplayName("게시글을 저장하면 자동으로 생성 날짜가 주입된다.")
+    @Test
+    void save_SavedPostWithCreatedDate_Success() {
+        // given
+        Images images = new Images(List.of(new Image(image)));
+        Post post = new Post(postContent, images, githubRepoUrl, user);
+
+        // when
+        Post savedPost = postRepository.save(post);
+
+        assertThat(savedPost.getCreatedAt()).isNotNull();
+        assertThat(savedPost.getCreatedAt()).isBefore(LocalDateTime.now());
     }
 
     @DisplayName("게시글을 저장할 때 태그도 함께 영속화된다.")


### PR DESCRIPTION
## 상세 내용
* @DataJpaTest는 DB 관려 Bean들만 로드하는데, Jpa Auditing을 허용하는 @EnableJpaAuditing 관련 설정을 로드하지 않아 서버 쪽에서는 빌드시 테스트가 실패합니다.
* 로컬에서는 테스트 성공했지만, 실제로 createdAt이라는 LocalDateTime이 null로 들어옴을 확인할 수 있었습니다.
* 이에 TestConfiguration을 추가했습니다.
   * SpringBoot 통합 테스트의 경우 @SpringApplication 애너테이션이 달린 클래스를 로드하는데, @EnableJpaAuditing을 해당 메인 클래스에 달아두면 SpringBoot 통합 테스트는 잘 동작하지만, @WebMvcTest는 실패하게 됩니다. @WebMvcTest 슬라이싱 테스트는 @SpringApplication 애너테이션 클래스를 탐색하지 않고 웹 관련 Bean들만 로드하기 때문입니다.
   * 다만 제가 @EnableJpaAuditing 애너테이션을 별도로 JpaConfiguration이라고 하는 @Configuration 파일에 분리해서, @WebMvcTest는 여태까지 터지지 않고 Auditing 관련 Bean을 잘 읽어들인것같네요.  (예전에 삽질했었는데... https://xlffm3.github.io/spring%20&%20spring%20boot/JPAError/)
* 추후 jpaAuditing 기능을 사용하고자 하는 모든 슬라이싱 테스트 (통합 테스트는 제외)는 해당 설정 파일을 임포트해야합니다.

## 기타
