### PR TITLE
[hotfix] s3storage bean 탐색을 하지 못하는 버그 수정

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/PostTestConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/PostTestConfiguration.java
@@ -4,17 +4,18 @@ import static java.util.stream.Collectors.toList;
 
 import com.woowacourse.pickgit.post.presentation.PickGitStorage;
 import java.io.File;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
-@TestConfiguration
-public class StorageConfiguration {
+@Configuration
+public class PostTestConfiguration {
 
     @Bean
+    @Profile("test")
     public PickGitStorage pickGitStorage() {
         return (files, userName) -> files.stream()
             .map(File::getName)
             .collect(toList());
     }
-
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/PickGitApplicationTests.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/PickGitApplicationTests.java
@@ -1,12 +1,12 @@
 package com.woowacourse.pickgit;
 
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
+@Import(PostTestConfiguration.class)
 @SpringBootTest
 @ActiveProfiles("test")
 class PickGitApplicationTests {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
@@ -7,7 +7,7 @@ import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileRespon
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthLoginUrlResponse;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -25,7 +25,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
+@Import(PostTestConfiguration.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceTest.java
@@ -9,8 +9,8 @@ import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.config.StorageConfiguration;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +22,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
-@DisplayName("OAuthService 통합 테스트 (UserRepository 사용)")
+@Import(PostTestConfiguration.class)@DisplayName("OAuthService 통합 테스트 (UserRepository 사용)")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
 public class OAuthServiceTest {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/dao/OAuthAccessTokenDaoTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/dao/OAuthAccessTokenDaoTest.java
@@ -2,7 +2,7 @@ package com.woowacourse.pickgit.authentication.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
+@Import(PostTestConfiguration.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
 class OAuthAccessTokenDaoTest {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/PostTestConfiguration.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/PostTestConfiguration.java
@@ -1,23 +1,12 @@
 package com.woowacourse.pickgit.post;
 
-import static java.util.stream.Collectors.toList;
-
 import com.woowacourse.pickgit.post.infrastructure.MockRepositoryApiRequester;
 import com.woowacourse.pickgit.post.infrastructure.PlatformRepositoryApiRequester;
-import com.woowacourse.pickgit.post.presentation.PickGitStorage;
-import java.io.File;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 @TestConfiguration
 public class PostTestConfiguration {
-
-    @Bean
-    public PickGitStorage pickGitStorage() {
-        return (files, userName) -> files.stream()
-            .map(File::getName)
-            .collect(toList());
-    }
 
     @Bean
     public PlatformRepositoryApiRequester platformRepositoryApiRequester() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/presentation/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/presentation/PostAcceptanceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.exception.dto.ApiErrorResponse;
 import com.woowacourse.pickgit.post.application.dto.CommentDto;
 import com.woowacourse.pickgit.post.domain.Post;
@@ -34,7 +34,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import({StorageConfiguration.class})
+@Import({PostTestConfiguration.class})
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/presentation/PostControllerTest.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.common.FileFactory;
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.exception.post.CommentFormatException;
 import com.woowacourse.pickgit.post.application.CommentRequestDto;
 import com.woowacourse.pickgit.post.application.PostService;
@@ -46,7 +46,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 
-@Import({StorageConfiguration.class})
+@Import({PostTestConfiguration.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(PostController.class)
 @ActiveProfiles("test")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/tag/presentation/TagAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/tag/presentation/TagAcceptanceTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.when;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
-import com.woowacourse.pickgit.config.StorageConfiguration;
 import com.woowacourse.pickgit.exception.dto.ApiErrorResponse;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.tag.TestTagConfiguration;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -29,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
 
-@Import({TestTagConfiguration.class, StorageConfiguration.class})
+@Import({TestTagConfiguration.class, PostTestConfiguration.class})
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/application/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/application/UserServiceIntegrationTest.java
@@ -6,16 +6,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.exception.user.DuplicateFollowException;
+import com.woowacourse.pickgit.exception.user.InvalidFollowException;
+import com.woowacourse.pickgit.exception.user.InvalidUserException;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.user.UserFactory;
 import com.woowacourse.pickgit.user.application.dto.AuthUserServiceDto;
 import com.woowacourse.pickgit.user.application.dto.FollowServiceDto;
 import com.woowacourse.pickgit.user.application.dto.UserProfileServiceDto;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
-import com.woowacourse.pickgit.exception.user.DuplicateFollowException;
-import com.woowacourse.pickgit.exception.user.InvalidFollowException;
-import com.woowacourse.pickgit.exception.user.InvalidUserException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +26,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
+@Import(PostTestConfiguration.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/integration/UserIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/user/integration/UserIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
-import com.woowacourse.pickgit.config.StorageConfiguration;
+import com.woowacourse.pickgit.post.PostTestConfiguration;
 import com.woowacourse.pickgit.user.UserFactory;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.presentation.dto.FollowResponseDto;
@@ -28,7 +28,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(StorageConfiguration.class)
+@Import(PostTestConfiguration.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")


### PR DESCRIPTION
## 상세 내용
* s3storage bean 정의된 configuration 파일이 두 개 존재해서 생기는 이슈 및 profile 수정
* 테스트는 잘 돌지만 현재 test profile로 어플리케이션 실행시 빌드가 되지 않음

## 기타
