### PR TITLE
[#152] 응답 파싱 에러 수정

### DIFF
--- a/backend/pick-git/build.gradle
+++ b/backend/pick-git/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5'
 
 	compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4'
 

--- a/backend/pick-git/build.gradle
+++ b/backend/pick-git/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5'
+	implementation 'org.apache.httpcomponents:httpclient:4.5'
 
 	compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4'
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/common/network/RestTemplateClient.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/common/network/RestTemplateClient.java
@@ -1,0 +1,288 @@
+package com.woowacourse.pickgit.common.network;
+
+import com.woowacourse.pickgit.post.infrastructure.RestClient;
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RequestCallback;
+import org.springframework.web.client.ResponseExtractor;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RestTemplateClient implements RestClient {
+
+    private static final int READ_TIMEOUT = 5000;
+    private static final int CONNECTION_REQUEST_TIMEOUT = 3000;
+    private static final int MAX_CONN_TOTAL = 100;
+    private static final int MAX_CONN_PER_ROUTE = 50;
+
+    public final RestTemplate restTemplate = createRestTemplate();
+
+    private static RestTemplate createRestTemplate() {
+        var factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setReadTimeout(READ_TIMEOUT);
+        factory.setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT);
+
+        CloseableHttpClient httpClient = HttpClientBuilder.create()
+            .setMaxConnTotal(MAX_CONN_TOTAL)
+            .setMaxConnPerRoute(MAX_CONN_PER_ROUTE)
+            .build();
+
+        factory.setHttpClient(httpClient);
+
+        return new RestTemplate(factory);
+    }
+
+    @Override
+    public <T> T getForObject(String url, Class<T> responseType, Object... uriVariables)
+        throws RestClientException {
+        return this.restTemplate.getForObject(url, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T getForObject(String url, Class<T> responseType, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.getForObject(url, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T getForObject(URI url, Class<T> responseType) throws RestClientException {
+        return this.restTemplate.getForObject(url, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> getForEntity(String url, Class<T> responseType,
+        Object... uriVariables) throws RestClientException {
+        return this.restTemplate.getForEntity(url, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> getForEntity(String url, Class<T> responseType,
+        Map<String, ?> uriVariables) throws RestClientException {
+        return this.restTemplate.getForEntity(url, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> getForEntity(URI url, Class<T> responseType)
+        throws RestClientException {
+        return this.restTemplate.getForEntity(url, responseType);
+    }
+
+    @Override
+    public HttpHeaders headForHeaders(String url, Object... uriVariables)
+        throws RestClientException {
+        return this.restTemplate.headForHeaders(url, uriVariables);
+    }
+
+    @Override
+    public HttpHeaders headForHeaders(String url, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.headForHeaders(url, uriVariables);
+    }
+
+    @Override
+    public HttpHeaders headForHeaders(URI url) throws RestClientException {
+        return this.restTemplate.headForHeaders(url);
+    }
+
+    @Override
+    public URI postForLocation(String url, Object request, Object... uriVariables)
+        throws RestClientException {
+        return this.restTemplate.postForLocation(url, request, uriVariables);
+    }
+
+    @Override
+    public URI postForLocation(String url, Object request, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.postForLocation(url, request, uriVariables);
+    }
+
+    @Override
+    public URI postForLocation(URI url, Object request) throws RestClientException {
+        return this.restTemplate.postForLocation(url, request);
+    }
+
+    @Override
+    public <T> T postForObject(String url, Object request, Class<T> responseType,
+        Object... uriVariables) throws RestClientException {
+        return this.restTemplate.postForObject(url, request,responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T postForObject(String url, Object request, Class<T> responseType,
+        Map<String, ?> uriVariables) throws RestClientException {
+        return this.restTemplate.postForObject(url, request,responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T postForObject(URI url, Object request, Class<T> responseType)
+        throws RestClientException {
+        return this.restTemplate.postForObject(url, request, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> postForEntity(String url, Object request, Class<T> responseType,
+        Object... uriVariables) throws RestClientException {
+        return this.restTemplate.postForEntity(url, request, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> postForEntity(String url, Object request, Class<T> responseType,
+        Map<String, ?> uriVariables) throws RestClientException {
+        return this.restTemplate.postForEntity(url, request, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> postForEntity(URI url, Object request, Class<T> responseType)
+        throws RestClientException {
+        return this.restTemplate.postForEntity(url, request, responseType);
+    }
+
+    @Override
+    public void put(String url, Object request, Object... uriVariables) throws RestClientException {
+        this.restTemplate.put(url, request, uriVariables);
+    }
+
+    @Override
+    public void put(String url, Object request, Map<String, ?> uriVariables)
+        throws RestClientException {
+        this.restTemplate.put(url, request);
+    }
+
+    @Override
+    public void put(URI url, Object request) throws RestClientException {
+        this.restTemplate.put(url, request);
+    }
+
+    @Override
+    public <T> T patchForObject(String url, Object request, Class<T> responseType,
+        Object... uriVariables) throws RestClientException {
+        return this.restTemplate.patchForObject(url, request, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T patchForObject(String url, Object request, Class<T> responseType,
+        Map<String, ?> uriVariables) throws RestClientException {
+        return this.restTemplate.patchForObject(url, request, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> T patchForObject(URI url, Object request, Class<T> responseType)
+        throws RestClientException {
+        return this.restTemplate.patchForObject(url, request, responseType);
+    }
+
+    @Override
+    public void delete(String url, Object... uriVariables) throws RestClientException {
+        this.restTemplate.delete(url, uriVariables);
+    }
+
+    @Override
+    public void delete(String url, Map<String, ?> uriVariables) throws RestClientException {
+        this.restTemplate.delete(url, uriVariables);
+    }
+
+    @Override
+    public void delete(URI url) throws RestClientException {
+        this.restTemplate.delete(url);
+    }
+
+    @Override
+    public Set<HttpMethod> optionsForAllow(String url, Object... uriVariables)
+        throws RestClientException {
+        return this.restTemplate.optionsForAllow(url, uriVariables);
+    }
+
+    @Override
+    public Set<HttpMethod> optionsForAllow(String url, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.optionsForAllow(url, uriVariables);
+    }
+
+    @Override
+    public Set<HttpMethod> optionsForAllow(URI url) throws RestClientException {
+        return this.restTemplate.optionsForAllow(url);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(String url, HttpMethod method,
+        HttpEntity<?> requestEntity, Class<T> responseType, Object... uriVariables)
+        throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(String url, HttpMethod method,
+        HttpEntity<?> requestEntity, Class<T> responseType, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity,
+        Class<T> responseType) throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(String url, HttpMethod method,
+        HttpEntity<?> requestEntity, ParameterizedTypeReference<T> responseType,
+        Object... uriVariables) throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(String url, HttpMethod method,
+        HttpEntity<?> requestEntity, ParameterizedTypeReference<T> responseType,
+        Map<String, ?> uriVariables) throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity,
+        ParameterizedTypeReference<T> responseType) throws RestClientException {
+        return this.restTemplate.exchange(url, method, requestEntity, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity, Class<T> responseType)
+        throws RestClientException {
+        return this.restTemplate.exchange(requestEntity, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity,
+        ParameterizedTypeReference<T> responseType) throws RestClientException {
+        return this.restTemplate.exchange(requestEntity, responseType);
+    }
+
+    @Override
+    public <T> T execute(String url, HttpMethod method, RequestCallback requestCallback,
+        ResponseExtractor<T> responseExtractor, Object... uriVariables) throws RestClientException {
+        return this.restTemplate.execute(url, method, requestCallback, responseExtractor, uriVariables);
+    }
+
+    @Override
+    public <T> T execute(String url, HttpMethod method, RequestCallback requestCallback,
+        ResponseExtractor<T> responseExtractor, Map<String, ?> uriVariables)
+        throws RestClientException {
+        return this.restTemplate.execute(url, method, requestCallback, responseExtractor, uriVariables);
+    }
+
+    @Override
+    public <T> T execute(URI url, HttpMethod method, RequestCallback requestCallback,
+        ResponseExtractor<T> responseExtractor) throws RestClientException {
+        return this.restTemplate.execute(url, method, requestCallback, responseExtractor);
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/RestClient.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/RestClient.java
@@ -1,0 +1,6 @@
+package com.woowacourse.pickgit.post.infrastructure;
+
+import org.springframework.web.client.RestOperations;
+
+public interface RestClient extends RestOperations {
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/infrastructure/S3StorageTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/infrastructure/S3StorageTest.java
@@ -45,5 +45,4 @@ class S3StorageTest {
             .usingRecursiveComparison()
             .isEqualTo(actual);
     }
-
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/infrastructure/S3StorageTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/post/infrastructure/S3StorageTest.java
@@ -1,0 +1,49 @@
+package com.woowacourse.pickgit.post.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.pickgit.common.FileFactory;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class S3StorageTest {
+
+    @InjectMocks
+    private S3Storage s3Storage;
+
+    @Mock
+    private RestClient restClient;
+
+    @DisplayName("이미지를 보내면 이미지 주소를 반환한다.")
+    @Test
+    void store_IfImagesGivenReturnUrls_True() {
+        //given
+        List<String> expected = List.of("testUrl1", "testUrl2");
+        given(restClient.postForEntity(any(), any(), any(), (Object) any()))
+            .willReturn(ResponseEntity.ok(
+                new S3Storage.StorageDto(expected))
+            );
+
+        List<String> actual = s3Storage.store(List.of(
+            FileFactory.getTestImage1File(),
+            FileFactory.getTestImage2File()
+        ), "testUser");
+
+        assertThat(expected)
+            .usingRecursiveComparison()
+            .isEqualTo(actual);
+    }
+
+}


### PR DESCRIPTION
## 상세 내용
- s3Proxy로부터 오는 응답 형식의 착오로 인한, 파싱 에러 수정.
    - 기존, ["url1", "url2"] 로 반환된다고 생각했으나, 실제로는 {urls:["url1","url2"]} 형식으로 반환.
- RestTemplate 의 ConnectionPool 사용을 위한 추상화
    - 기본 RestTemplate는 ConnectionsPool을 사용하지 않는다(스프링에서 기본적으로 SimpleRestTemplate 구현체를 사용하기 때문). 따라서 apache의  HttpClient를 이용하여 커넥션 풀을 이용할 수 있도록 수정