### PR TITLE
[#153] 서브모듈 branch 변경

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "backend/pick-git/security"]
 	path = backend/pick-git/security
 	url = https://github.com/2021-pick-git/security.git
+	branch = main


### PR DESCRIPTION
master -> main

## 상세 내용
서브 모듈의 기본 branch는 master로 설정, 하지만 main으로 rename됨에 따라 발생하는 에러를 해결한다.
https://leveloper.tistory.com/176

## 기타
