### PR TITLE
[#161] 회원/비회원 모두 받을 수 있는 API 토큰 검증 로직 수정

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
@@ -1,12 +1,12 @@
 package com.woowacourse.pickgit.authentication.application;
 
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
@@ -38,14 +38,14 @@ public class OAuthService {
     }
 
     @Transactional
-    public OAuthTokenResponse createToken(String code) {
+    public TokenDto createToken(String code) {
         String githubAccessToken = githubOAuthClient.getAccessToken(code);
 
         OAuthProfileResponse githubProfileResponse = githubOAuthClient.getGithubProfile(githubAccessToken);
 
         updateUserOrCreateUser(githubProfileResponse);
 
-        return new OAuthTokenResponse(createTokenAndSave(
+        return new TokenDto(createTokenAndSave(
             githubAccessToken,
             githubProfileResponse.getName()),
             githubProfileResponse.getName()

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/TokenDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/TokenDto.java
@@ -1,0 +1,31 @@
+package com.woowacourse.pickgit.authentication.application.dto;
+
+public class TokenDto {
+
+    private String token;
+    private String username;
+
+    public TokenDto() {
+    }
+
+    public TokenDto(String token, String username) {
+        this.token = token;
+        this.username = username;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/TokenDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/TokenDto.java
@@ -5,7 +5,7 @@ public class TokenDto {
     private String token;
     private String username;
 
-    public TokenDto() {
+    private TokenDto() {
     }
 
     public TokenDto(String token, String username) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/AuthorizationExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/AuthorizationExtractor.java
@@ -24,5 +24,6 @@ public class AuthorizationExtractor {
         }
 
         return null;
+
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolver.java
@@ -2,8 +2,10 @@ package com.woowacourse.pickgit.authentication.presentation;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.domain.Authenticated;
+import com.woowacourse.pickgit.authentication.presentation.interceptor.AuthHeader;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -27,7 +29,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
         NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        String authentication = (String) request.getAttribute("authentication");
+        String authentication = (String) request.getAttribute(AuthHeader.AUTHENTICATION);
 
         return oAuthService.findRequestUserByToken(authentication);
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/OAuthController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.pickgit.authentication.presentation;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthLoginUrlResponse;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +31,9 @@ public class OAuthController {
 
     @GetMapping("/afterlogin")
     public ResponseEntity<OAuthTokenResponse> afterAuthorizeGithubLogin(@RequestParam String code) {
+        TokenDto tokenDto = oauthService.createToken(code);
         return ResponseEntity
             .ok()
-            .body(oauthService.createToken(code));
+            .body(new OAuthTokenResponse(tokenDto.getToken(), tokenDto.getUsername()));
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthHeader.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthHeader.java
@@ -1,0 +1,6 @@
+package com.woowacourse.pickgit.authentication.presentation.interceptor;
+
+public interface AuthHeader {
+
+    String AUTHENTICATION = "Authentication";
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptor.java
@@ -6,6 +6,7 @@ import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -30,7 +31,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         if (!oAuthService.validateToken(authentication)) {
             throw new InvalidTokenException();
         }
-        request.setAttribute("authentication", authentication);
+        request.setAttribute(AuthHeader.AUTHENTICATION, authentication);
         return true;
     }
 
@@ -46,14 +47,14 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     }
 
     private boolean hasAccessControlRequestHeaders(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Access-Control-Request-Headers"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS));
     }
 
     private boolean hasAccessControlRequestMethod(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Access-Control-Request-Method"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD));
     }
 
     private boolean hasOrigin(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Origin"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ORIGIN));
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
@@ -26,15 +26,11 @@ public class IgnoreAuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String authentication = AuthorizationExtractor.extract(request);
-        request.setAttribute("authentication", getAppropriateAuthentication(authentication));
-        return true;
-    }
-
-    private String getAppropriateAuthentication(String authentication) {
-        if (!oAuthService.validateToken(authentication)) {
-            return null;
+        if (authentication != null && !oAuthService.validateToken(authentication)) {
+            throw new InvalidTokenException();
         }
-        return authentication;
+        request.setAttribute("authentication", authentication);
+        return true;
     }
 
     private boolean isPreflightRequest(HttpServletRequest request) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
@@ -6,6 +6,7 @@ import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -26,10 +27,10 @@ public class IgnoreAuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String authentication = AuthorizationExtractor.extract(request);
-        if (authentication != null && !oAuthService.validateToken(authentication)) {
+        if (Objects.nonNull(authentication) && !oAuthService.validateToken(authentication)) {
             throw new InvalidTokenException();
         }
-        request.setAttribute("authentication", authentication);
+        request.setAttribute(AuthHeader.AUTHENTICATION, authentication);
         return true;
     }
 
@@ -45,14 +46,14 @@ public class IgnoreAuthenticationInterceptor implements HandlerInterceptor {
     }
 
     private boolean hasAccessControlRequestHeaders(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Access-Control-Request-Headers"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS));
     }
 
     private boolean hasAccessControlRequestMethod(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Access-Control-Request-Method"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD));
     }
 
     private boolean hasOrigin(HttpServletRequest request) {
-        return Objects.nonNull(request.getHeader("Origin"));
+        return Objects.nonNull(request.getHeader(HttpHeaders.ORIGIN));
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/OAuthAcceptanceTest.java
@@ -68,8 +68,9 @@ public class OAuthAcceptanceTest {
     @Test
     void Authorization_Redirection_ReturnJwtToken() {
         // then
-        String token = 로그인_되어있음().getToken();
-        assertThat(token).isNotBlank();
+        OAuthTokenResponse tokenResponse = 로그인_되어있음();
+        assertThat(tokenResponse.getToken()).isNotBlank();
+        assertThat(tokenResponse.getUsername()).isEqualTo("pick-git-login");
     }
 
     public OAuthTokenResponse 로그인_되어있음() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/application/OAuthServiceMockTest.java
@@ -7,13 +7,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
@@ -84,7 +84,7 @@ class OAuthServiceMockTest {
         when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
 
         // when
-        OAuthTokenResponse token = oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(code);
 
         // then
         assertThat(token.getToken()).isEqualTo(jwtToken);
@@ -119,7 +119,7 @@ class OAuthServiceMockTest {
         when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
 
         // when
-        OAuthTokenResponse token = oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(code);
 
         // then
         assertThat(token.getToken()).isEqualTo(jwtToken);

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolverTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/AuthenticationPrincipalArgumentResolverTest.java
@@ -10,6 +10,7 @@ import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
+import com.woowacourse.pickgit.authentication.presentation.interceptor.AuthHeader;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import com.woowacourse.pickgit.exception.authentication.UnauthorizedException;
 import javax.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.ServletWebRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,7 +58,7 @@ class AuthenticationPrincipalArgumentResolverTest {
         oAuthAccessTokenDao.insert(jwtToken, accessToken);
 
         // mock
-        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+        when(httpServletRequest.getAttribute(AuthHeader.AUTHENTICATION)).thenReturn(jwtToken);
 
         // when
         AppUser loginUser = (AppUser) authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
@@ -74,7 +76,7 @@ class AuthenticationPrincipalArgumentResolverTest {
         String jwtToken = "invalid jwt token";
 
         // mock
-        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+        when(httpServletRequest.getAttribute(AuthHeader.AUTHENTICATION)).thenReturn(jwtToken);
 
         // then
         assertThatThrownBy(() -> {
@@ -89,7 +91,7 @@ class AuthenticationPrincipalArgumentResolverTest {
         String jwtToken = jwtTokenProvider.createToken("pick-git");
 
         // when
-        when(httpServletRequest.getAttribute("authentication")).thenReturn(jwtToken);
+        when(httpServletRequest.getAttribute(AuthHeader.AUTHENTICATION)).thenReturn(jwtToken);
 
         assertThatThrownBy(() -> {
             authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);
@@ -100,7 +102,7 @@ class AuthenticationPrincipalArgumentResolverTest {
     @Test
     void resolveArgument_InValidUserToken_ReturnGuest() throws Exception {
         // mock
-        when(httpServletRequest.getAttribute("authentication")).thenReturn(null);
+        when(httpServletRequest.getAttribute(AuthHeader.AUTHENTICATION)).thenReturn(null);
 
         // when
         AppUser loginUser = (AppUser) authenticationPrincipalArgumentResolver.resolveArgument(null, null, new ServletWebRequest(httpServletRequest), null);

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/OAuthControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.pickgit.authentication.application.OAuthService;
-import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +48,7 @@ class OAuthControllerTest {
     void afterAuthorizeGithubLogin_ValidAccount_JWTToken() throws Exception {
         // given
         String githubAuthorizationCode = "random";
-        when(oAuthService.createToken(githubAuthorizationCode)).thenReturn(new OAuthTokenResponse("jwt token", "binghe"));
+        when(oAuthService.createToken(githubAuthorizationCode)).thenReturn(new TokenDto("jwt token", "binghe"));
 
         // when, then
         mockMvc.perform(get("/api/afterlogin?code=" + githubAuthorizationCode))

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/AuthenticationInterceptorTest.java
@@ -97,7 +97,7 @@ class AuthenticationInterceptorTest {
         String bearerToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
 
         // mock
-        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.GET.toString());
         when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION)).thenReturn(Collections.enumeration(
             List.of(bearerToken)));
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptorTest.java
@@ -2,7 +2,7 @@ package com.woowacourse.pickgit.authentication.presentation.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,12 +52,12 @@ class IgnoreAuthenticationInterceptorTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(
-            Collections.enumeration(List.of(validToken)));
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.enumeration(List.of(validToken)));
 
         // when, then
         assertThat(ignoreAuthenticationInterceptor.preHandle(request, null, null)).isTrue();
-        verify(request, times(2)).setAttribute(any(String.class), any(String.class));
+        verify(request, times(2)).setAttribute(anyString(), anyString());
     }
 
     @DisplayName("토큰이 아예 없으면 true를 반환한다. (GuestUser)")
@@ -65,7 +65,8 @@ class IgnoreAuthenticationInterceptorTest {
     void preHandle_WithOutToken_ReturnTrue() throws Exception {
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(Collections.emptyEnumeration());
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.emptyEnumeration());
 
         // when, then
         assertThat(ignoreAuthenticationInterceptor.preHandle(request, null, null)).isTrue();
@@ -79,11 +80,13 @@ class IgnoreAuthenticationInterceptorTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(
-            Collections.enumeration(List.of(invalidToken)));
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.enumeration(List.of(invalidToken)));
 
         // when, then
         assertThatThrownBy(() -> ignoreAuthenticationInterceptor.preHandle(request, null, null))
-            .isInstanceOf(InvalidTokenException.class);
+            .isInstanceOf(InvalidTokenException.class)
+            .extracting("errorCode")
+            .isEqualTo("A0001");
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptorTest.java
@@ -1,0 +1,89 @@
+package com.woowacourse.pickgit.authentication.presentation.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
+import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.infrastructure.AuthorizationExtractor;
+import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
+import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+
+@ExtendWith(MockitoExtension.class)
+class IgnoreAuthenticationInterceptorTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private OAuthService oAuthService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    private IgnoreAuthenticationInterceptor ignoreAuthenticationInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProviderImpl("pick-git", 3600000);
+        oAuthService = new OAuthService(null, jwtTokenProvider, null, null);
+        ignoreAuthenticationInterceptor = new IgnoreAuthenticationInterceptor(oAuthService);
+    }
+
+    @DisplayName("유효한 토큰을 가진 회원이면 true를 반환한다.")
+    @Test
+    void preHandle_WithValidToken_ReturnTrue() throws Exception {
+        // given
+        String validToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
+
+        // mock
+        given(request.getMethod()).willReturn(HttpMethod.GET.toString());
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(
+            Collections.enumeration(List.of(validToken)));
+
+        // when, then
+        assertThat(ignoreAuthenticationInterceptor.preHandle(request, null, null)).isTrue();
+        verify(request, times(2)).setAttribute(any(String.class), any(String.class));
+    }
+
+    @DisplayName("토큰이 아예 없으면 true를 반환한다. (GuestUser)")
+    @Test
+    void preHandle_WithOutToken_ReturnTrue() throws Exception {
+        // mock
+        given(request.getMethod()).willReturn(HttpMethod.GET.toString());
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(Collections.emptyEnumeration());
+
+        // when, then
+        assertThat(ignoreAuthenticationInterceptor.preHandle(request, null, null)).isTrue();
+    }
+
+    @DisplayName("토큰이 존재하지만 유효하지 않으면 InvalidTokenException을 던진다.")
+    @Test
+    void preHandle_WithInvalidToken_ThrowException() {
+        // given
+        String invalidToken = "Bearer invalid token";
+
+        // mock
+        given(request.getMethod()).willReturn(HttpMethod.GET.toString());
+        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION)).willReturn(
+            Collections.enumeration(List.of(invalidToken)));
+
+        // when, then
+        assertThatThrownBy(() -> ignoreAuthenticationInterceptor.preHandle(request, null, null))
+            .isInstanceOf(InvalidTokenException.class);
+    }
+}


### PR DESCRIPTION
## 상세 내용
- 회원/비회원 모두 처리하는 API에서 토큰을 포함하여 보냈다는 것은 로그인이 된 상태인 것이 더 자연스럽다는 의견에 따라 수정한다.
- 기존 로직: 회원/비회원 모두 처리하는 API (ex. /api/posts)에서 토큰이 잘못된 경우 GuestUser로 처리.
- 수정 로직: 회원/비회원 모두 처리하는 API (ex. /api/posts)에서 토큰이 잘못된 경우 401 예외 발생.

## 기타
