### PR TITLE
[#169] 파일 주소가 제대로 반환되지 않는 버그 수정

### DIFF
--- a/s3-proxy/s3-proxy/src/main/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGenerator.java
+++ b/s3-proxy/s3-proxy/src/main/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGenerator.java
@@ -1,10 +1,12 @@
 package com.woowacourse.s3proxy.web.infrastructure;
 
 import com.woowacourse.s3proxy.exception.PickGitStorageException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.tika.Tika;
 import org.apache.tika.mime.MimeType;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
@@ -13,6 +15,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class FileNameGenerator {
+    private static final Tika tika = new Tika();
+
 
     public String generate(MultipartFile multipartFile, String userName) {
         return md5(multipartFile, userName) + extension(multipartFile);
@@ -21,9 +25,11 @@ public class FileNameGenerator {
     private String extension(MultipartFile multipartFile) {
         MimeTypes defaultMimeTypes = MimeTypes.getDefaultMimeTypes();
         try {
-            MimeType mimeType = defaultMimeTypes.forName(multipartFile.getContentType());
+            MimeType mimeType = defaultMimeTypes.forName(
+                tika.detect(multipartFile.getBytes())
+            );
             return mimeType.getExtension();
-        } catch (MimeTypeException e) {
+        } catch (MimeTypeException | IOException e) {
             throw new PickGitStorageException("확장자 추출 실패");
         }
     }

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/S3ProxyAcceptanceTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/S3ProxyAcceptanceTest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.s3proxy;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import cloud.localstack.docker.LocalstackDockerExtension;
@@ -26,9 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.multipart.MultipartFile;
 
 @Import(StorageTestConfiguration.class)
 @LocalstackDockerProperties(services = {"s3"}, platform = "linux/x86_64")

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/S3ProxyAcceptanceTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/S3ProxyAcceptanceTest.java
@@ -11,8 +11,6 @@ import com.woowacourse.s3proxy.exception.ExceptionAdvice.ExceptionDto;
 import com.woowacourse.s3proxy.web.presentation.Dto.Files;
 import com.woowacourse.s3proxy.web.presentation.Dto.Files.Response;
 import io.restassured.RestAssured;
-import io.restassured.specification.MultiPartSpecification;
-import io.restassured.specification.RequestSender;
 import io.restassured.specification.RequestSpecification;
 import java.io.File;
 import java.io.IOException;
@@ -22,14 +20,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.parsing.FailFastProblemReporter;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.multipart.MultipartFile;
 
 @Import(StorageTestConfiguration.class)
 @LocalstackDockerProperties(services = {"s3"}, platform = "linux/x86_64")

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/common/FileFactory.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/common/FileFactory.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.util.Objects;
 import org.apache.tika.Tika;
-
 import org.springframework.mock.web.MockMultipartFile;
 
 public class FileFactory {

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/common/fileValidator/ImageFileValidatorTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/common/fileValidator/ImageFileValidatorTest.java
@@ -1,17 +1,15 @@
 package com.woowacourse.s3proxy.common.fileValidator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.s3proxy.common.FileFactory;
 import com.woowacourse.s3proxy.exception.UploadFailException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 class ImageFileValidatorTest {

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/config/StorageTestConfiguration.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/config/StorageTestConfiguration.java
@@ -2,15 +2,9 @@ package com.woowacourse.s3proxy.config;
 
 import cloud.localstack.awssdkv1.TestUtils;
 import com.amazonaws.services.s3.AmazonS3;
-import com.woowacourse.s3proxy.common.fileValidator.ImageFileValidator;
-import java.awt.Image;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import org.springframework.test.context.ActiveProfiles;
 
 @TestConfiguration
 public class StorageTestConfiguration {

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.s3proxy.web.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.woowacourse.s3proxy.common.FileFactory;
 import java.util.stream.Stream;

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
@@ -22,7 +22,6 @@ class FileNameGeneratorTest {
     void generate(MultipartFile multipartFile, String extension) {
         String generatedFileName = generateFileName(multipartFile);
 
-        System.out.println(generatedFileName);
         assertThat(generatedFileName).endsWith(extension);
     }
 

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/FileNameGeneratorTest.java
@@ -22,6 +22,7 @@ class FileNameGeneratorTest {
     void generate(MultipartFile multipartFile, String extension) {
         String generatedFileName = generateFileName(multipartFile);
 
+        System.out.println(generatedFileName);
         assertThat(generatedFileName).endsWith(extension);
     }
 

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/S3StorageIntegrationTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/S3StorageIntegrationTest.java
@@ -1,29 +1,23 @@
 package com.woowacourse.s3proxy.web.infrastructure;
 
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import cloud.localstack.docker.LocalstackDockerExtension;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.woowacourse.s3proxy.common.FileFactory;
-import com.woowacourse.s3proxy.config.StorageConfiguration;
 import com.woowacourse.s3proxy.config.StorageTestConfiguration;
 import com.woowacourse.s3proxy.web.domain.PickGitStorage;
-import org.apache.http.entity.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import static java.util.stream.Collectors.teeing;
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(StorageTestConfiguration.class)
 @LocalstackDockerProperties(services = {"s3"}, platform = "linux/x86_64")

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/S3StorageIntegrationTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/infrastructure/S3StorageIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest
 class S3StorageIntegrationTest {
+    private static final FileNameGenerator fileNameGenerator = new FileNameGenerator();
 
     @Value("${aws.cloud_front.file_url_format}")
     private String fileUrlFormat;
@@ -40,15 +41,16 @@ class S3StorageIntegrationTest {
         String userName = "testUser";
 
         List<PickGitStorage.StoreResult> storeResults =
-                s3Storage.store(List.of(image1, image2), userName);
+            s3Storage.store(List.of(image1, image2), userName);
 
         assertThat(storeResults)
-                .usingRecursiveComparison()
-                .isEqualTo(List.of(
-                        createStoreResult(image1.getOriginalFilename()),
-                        createStoreResult(image2.getOriginalFilename())
-                        )
-                );
+            .usingRecursiveComparison()
+            .isEqualTo(List.of(
+                createStoreResult(fileNameGenerator.generate(image1, userName)),
+                createStoreResult(fileNameGenerator.generate(image2, userName))
+                )
+            );
+
     }
 
     @DisplayName("S3에 파일을 업로드 하고 실패한 파일과 성공한 파일의 결과를 확인한다. - 성공")
@@ -59,9 +61,9 @@ class S3StorageIntegrationTest {
         String userName = "testUser";
 
         List<Boolean> succeeds = s3Storage.store(List.of(image1, image2), userName).stream()
-                .map(PickGitStorage.StoreResult::isSucceed)
-                .filter(b -> b)
-                .collect(toList());
+            .map(PickGitStorage.StoreResult::isSucceed)
+            .filter(b -> b)
+            .collect(toList());
 
         assertThat(succeeds).hasSize(2);
     }
@@ -69,8 +71,8 @@ class S3StorageIntegrationTest {
 
     private PickGitStorage.StoreResult createStoreResult(String fileName) {
         return new PickGitStorage.StoreResult(
-                fileName,
-                String.format(fileUrlFormat, fileName)
+            fileName,
+            String.format(fileUrlFormat, fileName)
         );
     }
 }

--- a/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/presentation/PickGitStorageControllerTest.java
+++ b/s3-proxy/s3-proxy/src/test/java/com/woowacourse/s3proxy/web/presentation/PickGitStorageControllerTest.java
@@ -2,22 +2,18 @@ package com.woowacourse.s3proxy.web.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.amazonaws.services.s3.transfer.Upload;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.s3proxy.common.FileFactory;
 import com.woowacourse.s3proxy.exception.UploadFailException;
 import com.woowacourse.s3proxy.web.application.PickGitStorageService;
 import com.woowacourse.s3proxy.web.application.dto.FilesDto;
 import com.woowacourse.s3proxy.web.presentation.Dto.Files;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 상세 내용

#160 를 통해 수정하였으나, 실제 요청 시 본래 파일 이름을 기반으로 url이 생성되는 문제가 존재하였다.

소스를 확인해본 결과, 변경되어야 하는 부분이 여러곳임을 확인했고, 이를 기반으로 다시 코드를 작성하고 테스트를 작성하였다.

기존 테스트에서 거르지 못한 이유는... 변경 전 로직이 _파일 전송 -> 파일 주소 반환 -> 테스트 코드에서도 같은 파일 기반으로 주소 생성 -> 같은지 확인_ 이었는데 주소를 생성하는 프로덕션 코드에 수정이 없었기에 거르지 못했었음..

프로덕션 코드를 모두 수정하고 실패하는 테스트에 대한 수정 완료.

## 기타
