### PR TITLE
[#240] Authentication 관련 테스트 코드 리팩토링

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/OAuthService.java
@@ -1,7 +1,7 @@
 package com.woowacourse.pickgit.authentication.application;
 
-import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
@@ -41,7 +41,8 @@ public class OAuthService {
     public TokenDto createToken(String code) {
         String githubAccessToken = githubOAuthClient.getAccessToken(code);
 
-        OAuthProfileResponse githubProfileResponse = githubOAuthClient.getGithubProfile(githubAccessToken);
+        OAuthProfileResponse githubProfileResponse = githubOAuthClient
+            .getGithubProfile(githubAccessToken);
 
         updateUserOrCreateUser(githubProfileResponse);
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/OAuthProfileResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/application/dto/OAuthProfileResponse.java
@@ -3,7 +3,9 @@ package com.woowacourse.pickgit.authentication.application.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.pickgit.user.domain.profile.BasicProfile;
 import com.woowacourse.pickgit.user.domain.profile.GithubProfile;
+import lombok.Builder;
 
+@Builder
 public class OAuthProfileResponse {
 
     @JsonProperty("login")
@@ -43,18 +45,6 @@ public class OAuthProfileResponse {
         this.twitter = twitter;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getImage() {
-        return image;
-    }
-
     public GithubProfile toGithubProfile() {
         return new GithubProfile(
             githubUrl,
@@ -73,55 +63,35 @@ public class OAuthProfileResponse {
         );
     }
 
-    public void setImage(String image) {
-        this.image = image;
+    public String getName() {
+        return name;
+    }
+
+    public String getImage() {
+        return image;
     }
 
     public String getDescription() {
         return description;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public String getGithubUrl() {
         return githubUrl;
-    }
-
-    public void setGithubUrl(String githubUrl) {
-        this.githubUrl = githubUrl;
     }
 
     public String getCompany() {
         return company;
     }
 
-    public void setCompany(String company) {
-        this.company = company;
-    }
-
     public String getLocation() {
         return location;
-    }
-
-    public void setLocation(String location) {
-        this.location = location;
     }
 
     public String getWebsite() {
         return website;
     }
 
-    public void setWebsite(String website) {
-        this.website = website;
-    }
-
     public String getTwitter() {
         return twitter;
-    }
-
-    public void setTwitter(String twitter) {
-        this.twitter = twitter;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/AuthorizationExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/AuthorizationExtractor.java
@@ -4,9 +4,10 @@ import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
 public class AuthorizationExtractor {
-    public static final String AUTHORIZATION = "Authorization";
-    public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
-    public static String BEARER_TYPE = "Bearer";
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+    private static String BEARER_TYPE = "Bearer";
 
     public static String extract(HttpServletRequest request) {
         Enumeration<String> headers = request.getHeaders(AUTHORIZATION);

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/GithubOAuthClient.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/GithubOAuthClient.java
@@ -4,6 +4,8 @@ import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileRespon
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.infrastructure.dto.OAuthAccessTokenRequest;
 import com.woowacourse.pickgit.authentication.infrastructure.dto.OAuthAccessTokenResponse;
+import com.woowacourse.pickgit.exception.platform.PlatformException;
+import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -50,7 +52,7 @@ public class GithubOAuthClient implements OAuthClient {
             .getAccessToken();
 
         if (accessToken == null) {
-            throw new IllegalArgumentException("깃헙 인증 에러");
+            throw new PlatformHttpErrorException();
         }
         return accessToken;
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/presentation/interceptor/IgnoreAuthenticationInterceptor.java
@@ -20,7 +20,9 @@ public class IgnoreAuthenticationInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
         Object handler) throws Exception {
         if (isPreflightRequest(request)) {
             return true;

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
@@ -1,11 +1,11 @@
-package com.woowacourse.pickgit.unit.authentication.presentation.interceptor;
+package com.woowacourse.pickgit.integration.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
@@ -26,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
-class AuthenticationInterceptorTest {
+class AuthenticationInterceptorIntegrationTest {
 
     private JwtTokenProvider jwtTokenProvider;
 
@@ -49,11 +49,12 @@ class AuthenticationInterceptorTest {
     @Test
     void preHandle_CORS_True() throws Exception {
         // mock
-        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
-        when(httpServletRequest.getHeader("Access-Control-Request-Headers"))
-            .thenReturn("X-PINGOTHER, Content-Type");
-        when(httpServletRequest.getHeader("Access-Control-Request-Method")).thenReturn("POST");
-        when(httpServletRequest.getHeader("Origin")).thenReturn("http://pick-git.example");
+        given(httpServletRequest.getMethod())
+            .willReturn(HttpMethod.OPTIONS.toString());
+        given(httpServletRequest.getHeader("Access-Control-Request-Headers"))
+            .willReturn("X-PINGOTHER, Content-Type");
+        given(httpServletRequest.getHeader("Access-Control-Request-Method")).willReturn("POST");
+        given(httpServletRequest.getHeader("Origin")).willReturn("http://pick-git.example");
 
         // then
         assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
@@ -66,9 +67,9 @@ class AuthenticationInterceptorTest {
         String validToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
 
         // mock, when
-        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
-        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
-            .thenReturn(Collections.enumeration(
+        given(httpServletRequest.getMethod()).willReturn(HttpMethod.OPTIONS.toString());
+        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.enumeration(
                 List.of(validToken)));
 
         // then
@@ -83,9 +84,9 @@ class AuthenticationInterceptorTest {
         String bearerToken = "Bearer " + "invalid token";
 
         // mock
-        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.toString());
-        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
-            .thenReturn(Collections.enumeration(
+        given(httpServletRequest.getMethod()).willReturn(HttpMethod.OPTIONS.toString());
+        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 
         // when, then
@@ -102,9 +103,9 @@ class AuthenticationInterceptorTest {
         String bearerToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
 
         // mock
-        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.GET.toString());
-        when(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
-            .thenReturn(Collections.enumeration(
+        given(httpServletRequest.getMethod()).willReturn(HttpMethod.GET.toString());
+        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+            .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 
         // when, then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 
 import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
-import com.woowacourse.pickgit.authentication.infrastructure.AuthorizationExtractor;
 import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
 import com.woowacourse.pickgit.authentication.presentation.interceptor.AuthenticationInterceptor;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
@@ -53,8 +52,10 @@ class AuthenticationInterceptorIntegrationTest {
             .willReturn(HttpMethod.OPTIONS.toString());
         given(httpServletRequest.getHeader("Access-Control-Request-Headers"))
             .willReturn("X-PINGOTHER, Content-Type");
-        given(httpServletRequest.getHeader("Access-Control-Request-Method")).willReturn("POST");
-        given(httpServletRequest.getHeader("Origin")).willReturn("http://pick-git.example");
+        given(httpServletRequest.getHeader("Access-Control-Request-Method"))
+            .willReturn("POST");
+        given(httpServletRequest.getHeader("Origin"))
+            .willReturn("http://pick-git.example");
 
         // then
         assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
@@ -67,8 +68,9 @@ class AuthenticationInterceptorIntegrationTest {
         String validToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
 
         // mock, when
-        given(httpServletRequest.getMethod()).willReturn(HttpMethod.OPTIONS.toString());
-        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(httpServletRequest.getMethod())
+            .willReturn(HttpMethod.OPTIONS.toString());
+        given(httpServletRequest.getHeaders("Authorization"))
             .willReturn(Collections.enumeration(
                 List.of(validToken)));
 
@@ -84,8 +86,9 @@ class AuthenticationInterceptorIntegrationTest {
         String bearerToken = "Bearer " + "invalid token";
 
         // mock
-        given(httpServletRequest.getMethod()).willReturn(HttpMethod.OPTIONS.toString());
-        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(httpServletRequest.getMethod())
+            .willReturn(HttpMethod.OPTIONS.toString());
+        given(httpServletRequest.getHeaders("Authorization"))
             .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 
@@ -103,8 +106,9 @@ class AuthenticationInterceptorIntegrationTest {
         String bearerToken = "Bearer " + jwtTokenProvider.createToken("pick-git");
 
         // mock
-        given(httpServletRequest.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(httpServletRequest.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(httpServletRequest.getMethod())
+            .willReturn(HttpMethod.GET.toString());
+        given(httpServletRequest.getHeaders("Authorization"))
             .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationInterceptorIntegrationTest.java
@@ -15,6 +15,7 @@ import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import java.util.Collections;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,7 @@ class AuthenticationInterceptorIntegrationTest {
         // mock, when
         given(httpServletRequest.getMethod())
             .willReturn(HttpMethod.OPTIONS.toString());
-        given(httpServletRequest.getHeaders("Authorization"))
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.enumeration(
                 List.of(validToken)));
 
@@ -88,7 +89,7 @@ class AuthenticationInterceptorIntegrationTest {
         // mock
         given(httpServletRequest.getMethod())
             .willReturn(HttpMethod.OPTIONS.toString());
-        given(httpServletRequest.getHeaders("Authorization"))
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 
@@ -108,7 +109,7 @@ class AuthenticationInterceptorIntegrationTest {
         // mock
         given(httpServletRequest.getMethod())
             .willReturn(HttpMethod.GET.toString());
-        given(httpServletRequest.getHeaders("Authorization"))
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.enumeration(
                 List.of(bearerToken)));
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationPrincipalArgumentResolverIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationPrincipalArgumentResolverIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.pickgit.unit.authentication.presentation;
+package com.woowacourse.pickgit.integration.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,7 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.ServletWebRequest;
 
 @ExtendWith(MockitoExtension.class)
-class AuthenticationPrincipalArgumentResolverTest {
+class AuthenticationPrincipalArgumentResolverIntegrationTest {
 
     private JwtTokenProvider jwtTokenProvider;
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationPrincipalArgumentResolverIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/AuthenticationPrincipalArgumentResolverIntegrationTest.java
@@ -39,11 +39,14 @@ class AuthenticationPrincipalArgumentResolverIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        jwtTokenProvider = new JwtTokenProviderImpl("pick-git", 3600000);
-        oAuthAccessTokenDao = new CollectionOAuthAccessTokenDao();
-        oAuthService = new OAuthService(null, jwtTokenProvider, oAuthAccessTokenDao, null);
-        authenticationPrincipalArgumentResolver = new AuthenticationPrincipalArgumentResolver(
-            oAuthService);
+        jwtTokenProvider =
+            new JwtTokenProviderImpl("pick-git", 3600000);
+        oAuthAccessTokenDao =
+            new CollectionOAuthAccessTokenDao();
+        oAuthService =
+            new OAuthService(null, jwtTokenProvider, oAuthAccessTokenDao, null);
+        authenticationPrincipalArgumentResolver =
+            new AuthenticationPrincipalArgumentResolver(oAuthService);
     }
 
     @DisplayName("유효한 토큰이면 LoginUser를 반환한다.")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.pickgit.unit.authentication.presentation.interceptor;
+package com.woowacourse.pickgit.integration.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
-class IgnoreAuthenticationInterceptorTest {
+class IgnoreAuthenticationInterceptorIntegrationTest {
 
     private JwtTokenProvider jwtTokenProvider;
 
@@ -61,7 +61,7 @@ class IgnoreAuthenticationInterceptorTest {
         verify(request, times(2)).setAttribute(anyString(), anyString());
     }
 
-    @DisplayName("토큰이 아예 없으면 true를 반환한다. (GuestUser)")
+    @DisplayName("토큰이 아예 없으면 true를 반환한다. - GuestUser인 경우")
     @Test
     void preHandle_WithOutToken_ReturnTrue() throws Exception {
         // mock

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
@@ -15,6 +15,7 @@ import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import java.util.Collections;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders("Authorization"))
+        given(request.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.enumeration(List.of(validToken)));
 
         // when, then
@@ -65,7 +66,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
     void preHandle_WithOutToken_ReturnTrue() throws Exception {
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders("Authorization"))
+        given(request.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.emptyEnumeration());
 
         // when, then
@@ -80,7 +81,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders("Authorization"))
+        given(request.getHeaders(HttpHeaders.AUTHORIZATION))
             .willReturn(Collections.enumeration(List.of(invalidToken)));
 
         // when, then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/IgnoreAuthenticationInterceptorIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 
 import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
-import com.woowacourse.pickgit.authentication.infrastructure.AuthorizationExtractor;
 import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
 import com.woowacourse.pickgit.authentication.presentation.interceptor.IgnoreAuthenticationInterceptor;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
@@ -53,7 +52,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(request.getHeaders("Authorization"))
             .willReturn(Collections.enumeration(List.of(validToken)));
 
         // when, then
@@ -66,7 +65,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
     void preHandle_WithOutToken_ReturnTrue() throws Exception {
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(request.getHeaders("Authorization"))
             .willReturn(Collections.emptyEnumeration());
 
         // when, then
@@ -81,7 +80,7 @@ class IgnoreAuthenticationInterceptorIntegrationTest {
 
         // mock
         given(request.getMethod()).willReturn(HttpMethod.GET.toString());
-        given(request.getHeaders(AuthorizationExtractor.AUTHORIZATION))
+        given(request.getHeaders("Authorization"))
             .willReturn(Collections.enumeration(List.of(invalidToken)));
 
         // when, then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
@@ -103,7 +103,7 @@ class OAuthServiceIntegrationTest {
         // when
         oAuthService.createToken(code);
 
-        oAuthProfileResponse.setCompany("@woowabros");
+        //oAuthProfileResponse.setCompany("@woowabros");
         oAuthService.createToken(code);
 
         // then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
@@ -2,17 +2,20 @@ package com.woowacourse.pickgit.integration.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
+import com.woowacourse.pickgit.exception.authentication.UnauthorizedException;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,12 +25,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
 @Import(InfrastructureTestConfiguration.class)
 @DisplayName("OAuthService 통합 테스트 (UserRepository 사용)")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 class OAuthServiceIntegrationTest {
 
     @MockBean
@@ -49,7 +55,7 @@ class OAuthServiceIntegrationTest {
     @Test
     void getGithubAuthorizationUrl_Anonymous_ReturnGithubAuthorizationUrl() {
         // mock
-        when(oAuthClient.getLoginUrl()).thenReturn("https://github.com/login/oauth/authorize?");
+        given(oAuthClient.getLoginUrl()).willReturn("https://github.com/login/oauth/authorize?");
 
         // when
         String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
@@ -64,23 +70,28 @@ class OAuthServiceIntegrationTest {
         // given
         String code = "oauth authorization code";
         String oauthAccessToken = "oauth access token";
-        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
-            "binghe", "image", null, "github.com/",
-            null, null, null, null
-        );
+        OAuthProfileResponse oAuthProfileResponse = OAuthProfileResponse.builder()
+            .name("binghe")
+            .image("image")
+            .githubUrl("github.com/")
+            .build();
 
         // mock
-        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
-        when(oAuthClient.getGithubProfile(oauthAccessToken))
-            .thenReturn(oAuthProfileResponse);
+        given(oAuthClient.getAccessToken(code)).willReturn(oauthAccessToken);
+        given(oAuthClient.getGithubProfile(oauthAccessToken))
+            .willReturn(oAuthProfileResponse);
 
         // when
-        oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(code);
 
         // then
-        User user = userRepository.findByBasicProfile_Name(oAuthProfileResponse.getName()).orElse(null);
+        assertThat(token.getToken()).isNotNull();
+        assertThat(token.getUsername()).isEqualTo(oAuthProfileResponse.getName());
+
+        User user = userRepository.findByBasicProfile_Name(token.getUsername()).orElse(null);
         assertThat(user).isNotNull();
         assertThat(user.getBasicProfile().getName()).isEqualTo("binghe");
+        assertThat(user.getImage()).isEqualTo("image");
         assertThat(user.getGithubProfile().getGithubUrl()).isEqualTo("github.com/");
     }
 
@@ -90,25 +101,40 @@ class OAuthServiceIntegrationTest {
         // given
         String code = "oauth authorization code";
         String oauthAccessToken = "oauth access token";
-        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
-            "binghe", "image", null, "github.com/",
-            null, null, null, null
-        );
+        OAuthProfileResponse previousOAuthProfileResponse = OAuthProfileResponse.builder()
+            .name("binghe")
+            .image("image")
+            .githubUrl("github.com/")
+            .build();
+
+        User existingUser = new User(previousOAuthProfileResponse.toBasicProfile(),
+            previousOAuthProfileResponse.toGithubProfile());
+        userRepository.save(existingUser);
+
+        OAuthProfileResponse changedOAuthProfileResponse = OAuthProfileResponse.builder()
+            .name("binghe")
+            .image("image")
+            .githubUrl("github.com/")
+            .company("@woowabros")
+            .build();
 
         // mock
-        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
-        when(oAuthClient.getGithubProfile(oauthAccessToken))
-            .thenReturn(oAuthProfileResponse);
+        given(oAuthClient.getAccessToken(code)).willReturn(oauthAccessToken);
+        given(oAuthClient.getGithubProfile(oauthAccessToken))
+            .willReturn(changedOAuthProfileResponse);
 
         // when
-        oAuthService.createToken(code);
-
-        //oAuthProfileResponse.setCompany("@woowabros");
-        oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(code);
 
         // then
-        User user = userRepository.findByBasicProfile_Name(oAuthProfileResponse.getName()).orElse(null);
+        assertThat(token.getToken()).isNotNull();
+        assertThat(token.getUsername()).isEqualTo(changedOAuthProfileResponse.getName());
+
+        User user = userRepository.findByBasicProfile_Name(token.getUsername()).orElse(null);
         assertThat(user).isNotNull();
+        assertThat(user.getBasicProfile().getName()).isEqualTo("binghe");
+        assertThat(user.getImage()).isEqualTo("image");
+        assertThat(user.getGithubProfile().getGithubUrl()).isEqualTo("github.com/");
         assertThat(user.getGithubProfile().getCompany()).isEqualTo("@woowabros");
     }
 
@@ -141,5 +167,20 @@ class OAuthServiceIntegrationTest {
         // when, then
         assertThatThrownBy(() -> oAuthService.findRequestUserByToken(token))
             .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @DisplayName("authentication이 Null 이라면 GuestUser를 반환한다.")
+    @Test
+    void findRequestUserByToken_NullAuthenticationParam_ReturnGuestUser() {
+        // given
+        // when
+        AppUser appUser = oAuthService.findRequestUserByToken(null);
+
+        // then
+        assertThat(appUser).isInstanceOf(GuestUser.class);
+        assertThatThrownBy(() -> appUser.getUsername())
+            .isInstanceOf(UnauthorizedException.class);
+        assertThatThrownBy(() -> appUser.getAccessToken())
+            .isInstanceOf(UnauthorizedException.class);
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/application/OAuthServiceTest.java
@@ -2,15 +2,17 @@ package com.woowacourse.pickgit.unit.authentication.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.application.JwtTokenProvider;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
-import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.application.dto.TokenDto;
 import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
@@ -33,6 +35,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class OAuthServiceTest {
 
+    private static final String GITHUB_CODE = "oauth authorization code";
+    private static final String OAUTH_ACCESS_TOKEN = "oauth access token";
+    private static final String JWT_TOKEN = "jwt token";
+
     @Mock
     private OAuthClient oAuthClient;
 
@@ -48,14 +54,14 @@ class OAuthServiceTest {
     @InjectMocks
     private OAuthService oAuthService;
 
-    @DisplayName("Github 로그인 URL을 반환한다.")
+    @DisplayName("Github 로그인 URL을 반환하는데 성공한다.")
     @Test
     void getGithubAuthorizationUrl_Anonymous_ReturnGithubAuthorizationUrl() {
         // given
         String url = "https://github.com/login..";
 
         // mock
-        when(oAuthClient.getLoginUrl()).thenReturn(url);
+        given(oAuthClient.getLoginUrl()).willReturn(url);
 
         // then
         assertThat(oAuthService.getGithubAuthorizationUrl()).isEqualTo(url);
@@ -65,13 +71,16 @@ class OAuthServiceTest {
     @Test
     void createToken_Signup_SaveUserProfile() {
         // given
-        String code = "oauth authorization code";
-        String oauthAccessToken = "oauth access token";
-        String jwtToken = "jwt token";
-
-        OAuthProfileResponse githubProfileResponse = new OAuthProfileResponse();
-        githubProfileResponse.setName("test");
-        githubProfileResponse.setDescription("hi~");
+        OAuthProfileResponse githubProfileResponse = OAuthProfileResponse.builder()
+            .name("name")
+            .image("img.png")
+            .description("bio")
+            .githubUrl("www.github.com")
+            .company("company")
+            .location("location")
+            .website("website")
+            .twitter("twitter")
+            .build();
 
         User user = new User(
             githubProfileResponse.toBasicProfile(),
@@ -79,34 +88,53 @@ class OAuthServiceTest {
         );
 
         // mock
-        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
-        when(oAuthClient.getGithubProfile(oauthAccessToken)).thenReturn(githubProfileResponse);
-        when(userRepository.findByBasicProfile_Name(githubProfileResponse.getName())).thenReturn(
-            Optional.empty());
-        when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
+        given(oAuthClient.getAccessToken(GITHUB_CODE))
+            .willReturn(OAUTH_ACCESS_TOKEN);
+        given(oAuthClient.getGithubProfile(OAUTH_ACCESS_TOKEN))
+            .willReturn(githubProfileResponse);
+        given(userRepository.findByBasicProfile_Name(githubProfileResponse.getName()))
+            .willReturn(Optional.empty());
+        given(jwtTokenProvider.createToken(githubProfileResponse.getName()))
+            .willReturn(JWT_TOKEN);
 
         // when
-        TokenDto token = oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(GITHUB_CODE);
 
         // then
-        assertThat(token.getToken()).isEqualTo(jwtToken);
-        verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
-        verify(userRepository, times(1)).save(user);
-        verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
-        verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
+        assertThat(token.getToken()).isEqualTo(JWT_TOKEN);
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name(anyString());
+        verify(userRepository, times(1))
+            .save(any(User.class));
+        verify(jwtTokenProvider, times(1))
+            .createToken(anyString());
+        verify(oAuthAccessTokenDao, times(1))
+            .insert(anyString(), anyString());
+
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name(githubProfileResponse.getName());
+        verify(userRepository, times(1))
+            .save(user);
+        verify(jwtTokenProvider, times(1))
+            .createToken(githubProfileResponse.getName());
+        verify(oAuthAccessTokenDao, times(1))
+            .insert(JWT_TOKEN, OAUTH_ACCESS_TOKEN);
     }
 
     @DisplayName("로그인(첫 로그인이 아닌경우)시 Github Profile을 가져와서 DB에 저장된 기존 정보를 update한다.")
     @Test
     void createToken_Signup_UpdateUserProfile() {
         // given
-        String code = "oauth authorization code";
-        String oauthAccessToken = "oauth access token";
-        String jwtToken = "jwt token";
-
-        OAuthProfileResponse githubProfileResponse = new OAuthProfileResponse();
-        githubProfileResponse.setName("test");
-        githubProfileResponse.setDescription("hi~");
+        OAuthProfileResponse githubProfileResponse = OAuthProfileResponse.builder()
+            .name("name")
+            .image("img.png")
+            .description("bio")
+            .githubUrl("www.github.com")
+            .company("company")
+            .location("location")
+            .website("website")
+            .twitter("twitter")
+            .build();
 
         User user = new User(
             githubProfileResponse.toBasicProfile(),
@@ -114,57 +142,75 @@ class OAuthServiceTest {
         );
 
         // mock
-        when(oAuthClient.getAccessToken(code)).thenReturn(oauthAccessToken);
-        when(oAuthClient.getGithubProfile(oauthAccessToken)).thenReturn(githubProfileResponse);
-        when(userRepository.findByBasicProfile_Name(githubProfileResponse.getName())).thenReturn(
-            Optional.of(user));
-        when(jwtTokenProvider.createToken(githubProfileResponse.getName())).thenReturn(jwtToken);
+        given(oAuthClient.getAccessToken(GITHUB_CODE))
+            .willReturn(OAUTH_ACCESS_TOKEN);
+        given(oAuthClient.getGithubProfile(OAUTH_ACCESS_TOKEN))
+            .willReturn(githubProfileResponse);
+        given(userRepository.findByBasicProfile_Name(githubProfileResponse.getName()))
+            .willReturn(Optional.of(user));
+        given(jwtTokenProvider.createToken(githubProfileResponse.getName()))
+            .willReturn(JWT_TOKEN);
 
         // when
-        TokenDto token = oAuthService.createToken(code);
+        TokenDto token = oAuthService.createToken(GITHUB_CODE);
 
         // then
-        assertThat(token.getToken()).isEqualTo(jwtToken);
-        verify(userRepository, times(1)).findByBasicProfile_Name(githubProfileResponse.getName());
-        verify(userRepository, never()).save(user);
-        verify(jwtTokenProvider, times(1)).createToken(githubProfileResponse.getName());
-        verify(oAuthAccessTokenDao, times(1)).insert(jwtToken, oauthAccessToken);
+        assertThat(token.getToken()).isEqualTo(JWT_TOKEN);
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name(anyString());
+        verify(userRepository, never())
+            .save(any(User.class));
+        verify(jwtTokenProvider, times(1))
+            .createToken(anyString());
+        verify(oAuthAccessTokenDao, times(1))
+            .insert(anyString(), anyString());
+
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name(githubProfileResponse.getName());
+        verify(userRepository, never())
+            .save(user);
+        verify(jwtTokenProvider, times(1))
+            .createToken(githubProfileResponse.getName());
+        verify(oAuthAccessTokenDao, times(1))
+            .insert(JWT_TOKEN, OAUTH_ACCESS_TOKEN);
     }
 
     @DisplayName("JWT 토큰을 통해 AccessTokenDB에서 LoginUser에 대한 정보를 가져온다.")
     @Test
     void findRequestUserByToken_ValidToken_ReturnAppUser() {
         // given
-        String token = "jwt token";
-        String accessToken = "oauth access token";
         String username = "pick-git";
 
         // mock
-        when(jwtTokenProvider.getPayloadByKey(token, "username")).thenReturn(username);
-        when(oAuthAccessTokenDao.findByKeyToken(token)).thenReturn(Optional.ofNullable(accessToken));
+        given(jwtTokenProvider.getPayloadByKey(JWT_TOKEN, "username"))
+            .willReturn(username);
+        given(oAuthAccessTokenDao.findByKeyToken(JWT_TOKEN))
+            .willReturn(Optional.ofNullable(OAUTH_ACCESS_TOKEN));
 
         // when
-        AppUser appUser = oAuthService.findRequestUserByToken(token);
+        AppUser appUser = oAuthService.findRequestUserByToken(JWT_TOKEN);
 
         // then
         assertThat(appUser).isInstanceOf(LoginUser.class);
         assertThat(appUser.getUsername()).isEqualTo(username);
-        assertThat(appUser.getAccessToken()).isEqualTo(accessToken);
+        assertThat(appUser.getAccessToken()).isEqualTo(OAUTH_ACCESS_TOKEN);
     }
 
     @DisplayName("AccessTokenDB에 저장되어 있지 않은 JWT 토큰이라면 예외가 발생한다.")
     @Test
     void findRequestUserByToken_NotFoundToken_ThrowException() {
         // given
-        String token = "never saved jwt token";
+        String notSavedToken = "not_saved_jwt_token";
         String username = "pick-git";
 
         // mock
-        when(jwtTokenProvider.getPayloadByKey(token, "username")).thenReturn(username);
-        when(oAuthAccessTokenDao.findByKeyToken(token)).thenReturn(Optional.empty());
+        given(jwtTokenProvider.getPayloadByKey(notSavedToken, "username"))
+            .willReturn(username);
+        given(oAuthAccessTokenDao.findByKeyToken(notSavedToken))
+            .willReturn(Optional.empty());
 
         // then
-        assertThatThrownBy(() -> oAuthService.findRequestUserByToken(token))
+        assertThatThrownBy(() -> oAuthService.findRequestUserByToken(notSavedToken))
             .isInstanceOf(InvalidTokenException.class);
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/application/OAuthServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/application/OAuthServiceTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
-@DisplayName("OAuthService Mock 단위 테스트")
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 class OAuthServiceTest {
@@ -211,7 +211,10 @@ class OAuthServiceTest {
 
         // then
         assertThatThrownBy(() -> oAuthService.findRequestUserByToken(notSavedToken))
-            .isInstanceOf(InvalidTokenException.class);
+            .isInstanceOf(InvalidTokenException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "A0001")
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.UNAUTHORIZED)
+            .hasMessage("토큰 인증 에러");
     }
 
     @DisplayName("빈 JWT 토큰이면 GuestUser를 반환한다.")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/dao/OAuthAccessTokenDaoTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/dao/OAuthAccessTokenDaoTest.java
@@ -5,40 +5,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.pickgit.authentication.dao.CollectionOAuthAccessTokenDao;
 import com.woowacourse.pickgit.authentication.dao.OAuthAccessTokenDao;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class OAuthAccessTokenDaoTest {
 
-    private OAuthAccessTokenDao oAuthAccessTokenDao;
+    private static final String TOKEN = "jwt token";
+    private static final String OAUTH_ACCESS_TOKEN = "oauth access token";
 
-    private String token;
-    private String oauthAccessToken;
+    private OAuthAccessTokenDao oAuthAccessTokenDao;
 
     @BeforeEach
     void setUp() {
         // given
         oAuthAccessTokenDao = new CollectionOAuthAccessTokenDao();
-        token = "jwt token";
-        oauthAccessToken = "oauth access token";
     }
 
+    @DisplayName("처음 생성된 JWT 토큰과 OAuth Access Token을 맵에 성공적으로 저장하고 불러온다.")
     @Test
     void insertAndFind_NonDuplicated_Save() {
         // when
-        oAuthAccessTokenDao.insert(token, oauthAccessToken);
+        oAuthAccessTokenDao.insert(TOKEN, OAUTH_ACCESS_TOKEN);
 
         // then
-        assertThat(oAuthAccessTokenDao.findByKeyToken(token).get()).isEqualTo(oauthAccessToken);
+        assertThat(oAuthAccessTokenDao.findByKeyToken(TOKEN).get()).isEqualTo(OAUTH_ACCESS_TOKEN);
     }
 
+    @DisplayName("이미 있는 JWT 토큰에 대해서 새로운 OAuth Access Token을 추가해도 성공적으로 덮어씌워진다.")
     @Test
     void insertAndFind_Duplicated_Save() {
         // when
-        oAuthAccessTokenDao.insert(token, oauthAccessToken);
-
-        oAuthAccessTokenDao.insert(token, "duplicated");
+        oAuthAccessTokenDao.insert(TOKEN, OAUTH_ACCESS_TOKEN);
+        oAuthAccessTokenDao.insert(TOKEN, "duplicated");
 
         // then
-        assertThat(oAuthAccessTokenDao.findByKeyToken(token).get()).isEqualTo("duplicated");
+        assertThat(oAuthAccessTokenDao.findByKeyToken(TOKEN).get()).isEqualTo("duplicated");
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/presentation/OAuthControllerTest.java
@@ -2,8 +2,8 @@ package com.woowacourse.pickgit.unit.authentication.presentation;
 
 import static com.woowacourse.pickgit.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.woowacourse.pickgit.docs.ApiDocumentUtils.getDocumentResponse;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -44,7 +44,7 @@ class OAuthControllerTest {
     void authorizationGithubUrl_InvalidAccount_GithubUrl() throws Exception {
         // given
         String githubAuthorizationGithubUrl = "http://github.authorization.url";
-        when(oAuthService.getGithubAuthorizationUrl()).thenReturn(githubAuthorizationGithubUrl);
+        given(oAuthService.getGithubAuthorizationUrl()).willReturn(githubAuthorizationGithubUrl);
 
         // when, then
         ResultActions perform = mockMvc.perform(get("/api/authorization/github"))
@@ -66,8 +66,8 @@ class OAuthControllerTest {
     void afterAuthorizeGithubLogin_ValidAccount_JWTToken() throws Exception {
         // given
         String githubAuthorizationCode = "random";
-        when(oAuthService.createToken(githubAuthorizationCode))
-            .thenReturn(new TokenDto("jwt token", "binghe"));
+        given(oAuthService.createToken(githubAuthorizationCode))
+            .willReturn(new TokenDto("jwt token", "binghe"));
 
         // when, then
         ResultActions perform = mockMvc

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/presentation/OAuthControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/authentication/presentation/OAuthControllerTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureRestDocs
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(OAuthController.class)
 @ActiveProfiles("test")
 class OAuthControllerTest {


### PR DESCRIPTION
## 상세 내용
# Unit Test

## OAuthControllerTest

1. Github 로그인 요청을 하면 Github 인증 URL을 반환한다.
2. Github 로그인 인증 후 토큰을 발행하여 반환한다.

**참고** 

- invalid 한 code가 올 수 있으나, 해당 예외 처리는 깃헙에서 하므로 따로 검증하지 않음

## OAuthAccessTokenDaoTest

1. 처음 생성된 JWT 토큰과 OAuth Access Token을 맵에 성공적으로 저장하고 불러온다.
2. 이미 있는 JWT 토큰에 대해서 새로운 OAuth Access Token을 추가해도 성공적으로 덮어씌워진다.

**고민할 부분**

- JWT 토큰을 덮어 씌우는 경우는? → ***JWT 토큰은 유효한데 github단에서 리프레시 된 경우***
- DAO에 토큰 제거 로직 필요 → ***보류***

## OAuthServiceTest

1. Github 로그인 URL을 반환한다. → 지나치게 단순해서 필요한 테스트인지 모르겠으나 유지 
2. 회원가입(첫 로그인)시 Github Profile을 가져와서 DB에 insert한다.
3. 로그인(첫 로그인이 아닌경우)시 Github Profile을 가져와서 DB에 저장된 기존 정보를 update한다. → ***update 된 여부를 확인하기는 어렵고 userRepository.save() 를 호출하지 않는 것으로 확인***
4. JWT 토큰을 통해 AccessTokenDB에서 LoginUser에 대한 정보를 가져온다. → Mocking 한 것을 테스트 하는 듯한 느낌이 있지만, 슬라이스 테스트이므로 단순 dto 매핑에 대한 테스트를 한다고 생각함
5. AccessTokenDB에 저장되어 있지 않은 JWT 토큰이라면 예외가 발생한다.
6. 빈 JWT 토큰이면 GuestUser를 반환한다.

**변경 사항**

- verify를 더 큰 범위로 지정한 것을 추가

# Integration Test

## AuthenticationPrincipalArgumentResolverTest

1. 유효한 토큰이면 `LoginUser`를 반환한다.
2. 유효하지 않은 토큰이면 예외가 발생한다.
3. AccessToken DB에 저장되어 있지 않은 토큰이라면 예외가 발생한다.
4. 요청 헤더에 authorization을 추가해주지 않으면 `GuestUser`가 반환된다.
- 현재 `JwtTokenProvider`, `OAuthAccessTokenDao`, `OAuthService`를 의존하고 있음
- 위 3개를 모킹할 수 있으나, 그러면 테스트하는 로직이 없어서 애매함
- 현재 있는 2, 3 의 예외케이스도 `OAuthService`에서 발생시키는 예외임
- `OAuthService`의 슬라이스 테스트와 매우 중복됨

**변경 사항**

- 현재 resolver 단위 테스트가 통합 테스트에 가까우므로 단위 테스트 → 통합 테스트로 이전하고 해당하는 예외 케이스에 대한 테스트를 작성하도록 함
- 불필요한 @InjectMock 제거

## AuthenticationInterceptorTest

1. CORS 프리플라이트 요청이면 true를 반환한다.
2. 유효한 토큰의 요청이면 `HttpServletRequest`에 토큰 정보를 저장하고 true를 반환한다.
3. 유효하지 않은 토큰의 요청이면 예외를 던진다.
4. 유효기간이 지난 토큰의 경우 예외가 발생한다.

**변경 사항**

- 리졸버와 마찬가지로 통합 테스트로의 의미가 더 강하므로 Unit → Integeration 패키지로 이전함

## IgnoreAuthenticationInterceptorIntegrationTest

1. 유효한 토큰을 가진 회원이면 true를 반환한다. - `LoginUser`인 경우
2. 토큰이 아예 없으면 true를 반환한다. - `GuestUser`인 경우
3. 토큰이 존재하지만 유효하지 않으면 `InvalidTokenException`을 던진다.

**변경 사항**

- 리졸버와 마찬가지로 통합 테스트로의 의미가 더 강하므로 Unit → Integeration 패키지로 이전함

## OAuthServiceIntegrationTest

1. Github 로그인 URL을 반환한다.
2. 회원가입(첫 로그인)시 Github Profile을 가져와서 DB에 insert한다.
3. 로그인(첫 로그인이 아닌경우)시 Github Profile을 가져와서 DB에 저장된 기존 정보를 update한다.
4. JWT 토큰을 통해 AccessTokenDB에서 LoginUser에 대한 정보를 가져온다.
5. AccessTokenDB에 저장되어 있지 않은 JWT 토큰이라면 예외가 발생한다.
6. authentication이 Null 이라면 GuestUser를 반환한다.

**변경 사항**

- OAuthProfileResponse 에 Builder 추가 및 setter삭제
- 테스트 케이스 추가

# Acceptance Test

## OAuthAcceptanceTest

1. 로그인 - Github OAuth 로그인 URL을 요청한다.
2. 로그인 - Github 인증후 리다이렉션을 통해 요청이 오면 토큰을 생성하여 반환한다.
3. 재 로그인 - 첫 로그인 이후로 동일한 유저로 로그인하면 정보 업데이트 후 토큰을 생성하여 반환한다.

**변경 사항**

- OAuthProfileResponse 빌더로 변경
- 테스트 케이스 추가
- code가 invalid 한 경우를 추가하려고 했으나, OAuthClient가 모킹되어 있으므로 불가

**질문**

- OAuthClient를 모킹한 이유<br/>

## 기타

<br/>

Close #240 
