### PR TITLE
[#246] 댓글 테스트 코드를 리팩토링

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
@@ -51,19 +51,17 @@ public class PostService {
     private final PickGitStorage pickgitStorage;
     private final PlatformRepositoryExtractor platformRepositoryExtractor;
     private final TagService tagService;
-    private final EntityManager entityManager;
 
     public PostService(UserRepository userRepository,
         PostRepository postRepository,
         PickGitStorage pickgitStorage,
         PlatformRepositoryExtractor platformRepositoryExtractor,
-        TagService tagService, EntityManager entityManager) {
+        TagService tagService) {
         this.userRepository = userRepository;
         this.postRepository = postRepository;
         this.pickgitStorage = pickgitStorage;
         this.platformRepositoryExtractor = platformRepositoryExtractor;
         this.tagService = tagService;
-        this.entityManager = entityManager;
     }
 
     public PostImageUrlResponseDto write(PostRequestDto postRequestDto) {
@@ -146,7 +144,6 @@ public class PostService {
             ));
         Comment comment = new Comment(commentRequest.getContent());
         user.addComment(post, comment);
-        entityManager.flush();
         return CommentResponse.from(comment);
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
@@ -51,17 +51,19 @@ public class PostService {
     private final PickGitStorage pickgitStorage;
     private final PlatformRepositoryExtractor platformRepositoryExtractor;
     private final TagService tagService;
+    private final EntityManager entityManager;
 
     public PostService(UserRepository userRepository,
         PostRepository postRepository,
         PickGitStorage pickgitStorage,
         PlatformRepositoryExtractor platformRepositoryExtractor,
-        TagService tagService) {
+        TagService tagService, EntityManager entityManager) {
         this.userRepository = userRepository;
         this.postRepository = postRepository;
         this.pickgitStorage = pickgitStorage;
         this.platformRepositoryExtractor = platformRepositoryExtractor;
         this.tagService = tagService;
+        this.entityManager = entityManager;
     }
 
     public PostImageUrlResponseDto write(PostRequestDto postRequestDto) {
@@ -144,6 +146,7 @@ public class PostService {
             ));
         Comment comment = new Comment(commentRequest.getContent());
         user.addComment(post, comment);
+        entityManager.flush();
         return CommentResponse.from(comment);
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/CommentResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/CommentResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 public class CommentResponse {
 
     private Long id;
+    private String profileImageUrl;
     private String authorName;
     private String content;
     private Boolean isLiked;
@@ -14,16 +15,23 @@ public class CommentResponse {
     private CommentResponse() {
     }
 
-    public CommentResponse(Long id, String authorName, String content, Boolean isLiked) {
+    public CommentResponse(Long id, String profileImageUrl, String authorName, String content,
+        Boolean isLiked) {
         this.id = id;
+        this.profileImageUrl = profileImageUrl;
         this.authorName = authorName;
         this.content = content;
         this.isLiked = isLiked;
     }
 
     public static CommentResponse from(Comment comment) {
-        return new CommentResponse(comment.getId(), comment.getAuthorName(),
-            comment.getContent(), false);
+        return CommentResponse.builder()
+            .id(comment.getId())
+            .profileImageUrl(comment.getProfileImageUrl())
+            .authorName(comment.getAuthorName())
+            .content(comment.getContent())
+            .isLiked(false)
+            .build();
     }
 
     public Long getId() {
@@ -40,5 +48,9 @@ public class CommentResponse {
 
     public Boolean getIsLiked() {
         return isLiked;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
@@ -90,6 +90,7 @@ public class Post {
     }
 
     public void addComment(Comment comment) {
+        comment.toPost(this);
         comments.addComment(comment);
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/comment/Comment.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/comment/Comment.java
@@ -78,4 +78,8 @@ public class Comment {
     public String getContent() {
         return content.getContent();
     }
+
+    public String getProfileImageUrl() {
+        return user.getImage();
+    }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/comment/CommentContent.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/comment/CommentContent.java
@@ -27,8 +27,8 @@ public class CommentContent {
 
     private boolean isNotValidContent(String content) {
         return Objects.isNull(content)
-            || content.isEmpty()
-            || content.length() > MAX_COMMENT_CONTENT_LENGTH;
+            || content.isBlank()
+            || content.length() >= MAX_COMMENT_CONTENT_LENGTH;
     }
 
     public String getContent() {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/request/CommentRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/request/CommentRequest.java
@@ -1,5 +1,8 @@
 package com.woowacourse.pickgit.post.presentation.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public class CommentRequest {
 
     private String userName;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -82,8 +82,7 @@ public class User {
     }
 
     public void addComment(Post post, Comment comment) {
-        comment.toPost(post)
-            .writeBy(this);
+        comment.writeBy(this);
         post.addComment(comment);
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
@@ -98,7 +98,7 @@ class PostAcceptanceTest {
             .auth().oauth2(token)
             .when()
             .get("/api/posts?page=0&limit=3")
-            .then()
+            .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(new TypeRef<List<PostResponseDto>>() {
@@ -119,7 +119,7 @@ class PostAcceptanceTest {
         List<PostResponseDto> response = given().log().all()
             .when()
             .get("/api/posts?page=0&limit=3")
-            .then()
+            .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(new TypeRef<List<PostResponseDto>>() {
@@ -141,7 +141,7 @@ class PostAcceptanceTest {
             .auth().oauth2(token)
             .when()
             .get("/api/posts/me?page=0&limit=3")
-            .then()
+            .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(new TypeRef<List<PostResponseDto>>() {
@@ -182,7 +182,7 @@ class PostAcceptanceTest {
             .auth().oauth2(loginUserToken)
             .when()
             .get("/api/posts/" + ANOTHER_USERNAME + "?page=0&limit=3")
-            .then()
+            .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(new TypeRef<List<PostResponseDto>>() {
@@ -203,7 +203,7 @@ class PostAcceptanceTest {
         List<PostResponseDto> response = given().log().all()
             .when()
             .get("/api/posts/" + ANOTHER_USERNAME + "?page=0&limit=3")
-            .then()
+            .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(new TypeRef<List<PostResponseDto>>() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
@@ -21,9 +21,13 @@ import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.Null;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -81,7 +85,7 @@ class PostAcceptanceTest {
         requestWrite(token);
     }
 
-    @DisplayName("로그인일때 게시물을 조회한다. - 댓글 및 게시글의 좋아요 여부를 확인할 수 있다.")
+    @DisplayName("로그인일때 게시물을 조회한다. - Comment 및 게시글의 좋아요 여부를 확인할 수 있다.")
     @Test
     void read_LoginUser_Success() {
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
@@ -103,7 +107,7 @@ class PostAcceptanceTest {
         assertThat(response).hasSize(3);
     }
 
-    @DisplayName("비 로그인이어도 게시글 조회가 가능하다. - 댓글 및 게시물 좋아요 여부는 항상 false")
+    @DisplayName("비 로그인이어도 게시글 조회가 가능하다. - Comment 및 게시물 좋아요 여부는 항상 false")
     @Test
     void read_GuestUser_Success() {
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
@@ -249,18 +253,19 @@ class PostAcceptanceTest {
             .extract();
     }
 
-    @DisplayName("사용자는 댓글을 등록할 수 있다.")
+    @DisplayName("User는 Comment을 등록할 수 있다.")
     @Test
     void addComment_LoginUser_Success() {
         // given
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
+        Long postId = 1L;
 
         requestWrite(token);
 
         ContentRequest request = new ContentRequest("this is content");
 
         // when
-        CommentResponse response = requestAddComment(token, request, HttpStatus.OK)
+        CommentResponse response = requestAddComment(token, postId, request, HttpStatus.OK)
             .as(CommentResponse.class);
 
         // then
@@ -282,60 +287,50 @@ class PostAcceptanceTest {
             .extract();
     }
 
-    @DisplayName("댓글 내용이 null인 경우 예외가 발생한다. - 400 예외")
-    @Test
-    void addComment_Null_400Exception() {
+    @DisplayName("Comment 내용이 빈 경우 예외가 발생한다. - 400 예외")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  "})
+    void addComment_NullOrEmpty_400Exception(String content) {
         // given
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
-        ContentRequest request = new ContentRequest(null);
+        Long postId = 1L;
+        ContentRequest request = new ContentRequest(content);
 
         // when
-        ApiErrorResponse response = requestAddComment(token, request, HttpStatus.BAD_REQUEST)
+        ApiErrorResponse response = requestAddComment(token, postId, request, HttpStatus.BAD_REQUEST)
             .as(ApiErrorResponse.class);
 
         // then
         assertThat(response.getErrorCode()).isEqualTo("F0001");
     }
 
-    @DisplayName("댓글 내용이 빈 칸인 경우 예외가 발생한다. - 400 예외")
+    @DisplayName("존재하지 않는 Post에 Comment를 등록할 수 없다. - 500 예외")
     @Test
-    void addComment_Empty_400Exception() {
+    void addComment_PostNotFound_500Exception() {
         // given
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
-        ContentRequest request = new ContentRequest("");
+        Long postId = 0L;
+        ContentRequest request = new ContentRequest("a");
 
         // when
-        ApiErrorResponse response = requestAddComment(token, request, HttpStatus.BAD_REQUEST)
+        ApiErrorResponse response = requestAddComment(token, postId, request, HttpStatus.INTERNAL_SERVER_ERROR)
             .as(ApiErrorResponse.class);
 
         // then
-        assertThat(response.getErrorCode()).isEqualTo("F0001");
+        assertThat(response.getErrorCode()).isEqualTo("P0002");
     }
 
-    @DisplayName("댓글 내용이 공백인 경우 예외가 발생한다. - 400 예외")
-    @Test
-    void addComment_Blank_400Exception() {
-        // given
-        String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
-        ContentRequest request = new ContentRequest(" ");
-
-        // when
-        ApiErrorResponse response = requestAddComment(token, request, HttpStatus.BAD_REQUEST)
-            .as(ApiErrorResponse.class);
-
-        // then
-        assertThat(response.getErrorCode()).isEqualTo("F0001");
-    }
-
-    @DisplayName("댓글 내용이 100자 초과인 경우 예외가 발생한다. - 400 예외")
+    @DisplayName("Comment 내용이 100자 초과인 경우 예외가 발생한다. - 400 예외")
     @Test
     void addComment_Over100_400Exception() {
         // given
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
+        Long postId = 1L;
         ContentRequest request = new ContentRequest("a".repeat(101));
 
         // when
-        ApiErrorResponse response = requestAddComment(token, request, HttpStatus.BAD_REQUEST)
+        ApiErrorResponse response = requestAddComment(token, postId, request, HttpStatus.BAD_REQUEST)
             .as(ApiErrorResponse.class);
 
         // then
@@ -344,6 +339,7 @@ class PostAcceptanceTest {
 
     private ExtractableResponse<Response> requestAddComment(
         String token,
+        Long postId,
         ContentRequest request,
         HttpStatus httpStatus) {
         return given().log().all()
@@ -351,7 +347,7 @@ class PostAcceptanceTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .body(request)
             .when()
-            .post("/api/posts/{postId}/comments", 1L)
+            .post("/api/posts/{postId}/comments", postId)
             .then().log().all()
             .statusCode(httpStatus.value())
             .extract();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
@@ -273,6 +273,27 @@ class PostAcceptanceTest {
         assertThat(response.getContent()).isEqualTo("this is content");
     }
 
+    @DisplayName("비로그인 User는 Comment를 등록할 수 없다.")
+    @Test
+    void addComment_GuestUser_Fail() {
+        // given
+        String writePostToken = 로그인_되어있음(ANOTHER_USERNAME).getToken();
+        String invalidToken = "invalid token";
+        Long postId = 1L;
+
+        requestWrite(writePostToken);
+
+        ContentRequest request = new ContentRequest("this is content");
+
+        // when
+        ApiErrorResponse response
+            = requestAddComment(invalidToken, postId, request, HttpStatus.UNAUTHORIZED)
+            .as(ApiErrorResponse.class);
+
+        // then
+        assertThat(response.getErrorCode()).isEqualTo("A0001");
+    }
+
     private void requestWrite(String token) {
         given().log().all()
             .auth().oauth2(token)

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
@@ -122,6 +122,7 @@ public class PostFactory {
     public static List<PostResponseDto> mockPostResponseDtos() {
         CommentResponse commentFixture1 = CommentResponse.builder()
             .id(1L)
+            .profileImageUrl("commentAuthorProfileImageUrl")
             .authorName("commentAuthorName1")
             .content("commentContent1")
             .isLiked(false)
@@ -129,6 +130,7 @@ public class PostFactory {
 
         CommentResponse commentFixture2 = CommentResponse.builder()
             .id(2L)
+            .profileImageUrl("commentAuthorProfileImageUrl")
             .authorName("commentAuthorName2")
             .content("commentContent2")
             .isLiked(false)

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -127,17 +127,20 @@ class PostRepositoryTest {
     @DisplayName("Post에 Comment를 추가하면 Comment가 자동 영속화된다.")
     @Test
     void addComment_WhenSavingPost_CommentSavedTogether() {
+        // given
         Post post =
             new Post(null, null, new PostContent("abc"), githubRepoUrl, null, new Comments(), new ArrayList<>(),
                 null);
-        Comment comment = new Comment("test comment")
-            .toPost(post);
+        Comment comment = new Comment("test comment");
         post.addComment(comment);
 
+        // when
         postRepository.save(post);
+
         testEntityManager.flush();
         testEntityManager.clear();
 
+        // then
         Post findPost = postRepository.findById(post.getId())
             .orElseThrow(IllegalArgumentException::new);
         List<Comment> comments = findPost.getComments();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/comment/CommentTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/comment/CommentTest.java
@@ -8,39 +8,40 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CommentTest {
 
     @DisplayName("100자 이하의 댓글을 생성할 수 있다.")
     @Test
     void newComment_Under100Length_Success() {
-        StringBuilder content = new StringBuilder();
-        for (int i = 0; i < 100; i++) {
-            content.append("a");
-        }
+        // given
+        String content = "a".repeat(99);
 
-        assertThatCode(() -> new Comment(content.toString()))
+        // when, then
+        assertThatCode(() -> new Comment(content))
             .doesNotThrowAnyException();
     }
 
     @DisplayName("100자 초과의 댓글을 생성할 수 없다.")
     @Test
     void newComment_Over100Length_ExceptionThrown() {
-        StringBuilder content = new StringBuilder();
-        for (int i = 0; i < 101; i++) {
-            content.append("a");
-        }
+        // given
+        String content = "a".repeat(100);
 
-        assertThatCode(() -> new Comment(content.toString()))
+        // when, then
+        assertThatCode(() -> new Comment(content))
             .isInstanceOf(CommentFormatException.class)
             .extracting("errorCode")
             .isEqualTo("F0002");
     }
 
-    @DisplayName("댓글은 null이거나 빈 문자열이어서는 안 된다.")
+    @DisplayName("댓글은 null이거나 빈 문자열(공백만 있는 문자열 포함)이면 생성할 수 없다.")
     @ParameterizedTest
     @NullAndEmptySource
+    @ValueSource(strings = {" ", "  "})
     void newComment_NullOrEmpty_ExceptionThrown(String content) {
+        // when, then
         assertThatCode(() -> new Comment(content))
             .isInstanceOf(CommentFormatException.class)
             .extracting("errorCode")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
@@ -199,6 +199,7 @@ class PostControllerTest {
         String requestBody = objectMapper.writeValueAsString(new ContentRequest("test comment"));
         CommentResponse commentResponse = CommentResponse.builder()
             .id(1L)
+            .profileImageUrl("kevin profile image url")
             .authorName("kevin")
             .content("test comment")
             .isLiked(false)
@@ -238,6 +239,7 @@ class PostControllerTest {
             ),
             responseFields(
                 fieldWithPath("id").type(NUMBER).description("댓글 id"),
+                fieldWithPath("profileImageUrl").type(STRING).description("댓글 작성자 프로필 사진"),
                 fieldWithPath("authorName").type(STRING).description("작성자 이름"),
                 fieldWithPath("content").type(STRING).description("댓글 내용"),
                 fieldWithPath("isLiked").type(BOOLEAN).description("좋아요 여부")
@@ -366,6 +368,7 @@ class PostControllerTest {
                 fieldWithPath("[].updatedAt").type(STRING).description("마지막 글 수정 시간"),
                 fieldWithPath("[].comments").type(ARRAY).description("댓글 목록"),
                 fieldWithPath("[].comments[].id").type(NUMBER).description("댓글 아이디"),
+                fieldWithPath("[].comments[].profileImageUrl").type(STRING).description("댓글 작성자 프로필 사진"),
                 fieldWithPath("[].comments[].authorName").type(STRING).description("댓글 작성자 이름"),
                 fieldWithPath("[].comments[].content").type(STRING).description("댓글 내용"),
                 fieldWithPath("[].comments[].isLiked").type(BOOLEAN).description("댓글 좋아요 여부"),
@@ -412,6 +415,7 @@ class PostControllerTest {
                 fieldWithPath("[].updatedAt").type(STRING).description("마지막 글 수정 시간"),
                 fieldWithPath("[].comments").type(ARRAY).description("댓글 목록"),
                 fieldWithPath("[].comments[].id").type(NUMBER).description("댓글 아이디"),
+                fieldWithPath("[].comments[].profileImageUrl").type(STRING).description("댓글 작성자 프로필 사진"),
                 fieldWithPath("[].comments[].authorName").type(STRING).description("댓글 작성자 이름"),
                 fieldWithPath("[].comments[].content").type(STRING).description("댓글 내용"),
                 fieldWithPath("[].comments[].isLiked").type(BOOLEAN).description("댓글 좋아요 여부"),

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
@@ -111,7 +111,6 @@ class PostControllerTest {
         postContent = "pickgit";
     }
 
-
     @DisplayName("게시물을 작성할 수 있다. - 사용자")
     @Test
     void write_LoginUser_Success() throws Exception {
@@ -190,31 +189,42 @@ class PostControllerTest {
         ));
     }
 
-    @DisplayName("특정 Post에 댓글을 추가한다.")
+    @DisplayName("특정 Post에 Comment을 추가한다.")
     @Test
     void addComment_ValidContent_Success() throws Exception {
+        // given
         LoginUser loginUser = new LoginUser("kevin", "token");
+        String url = "/api/posts/{postId}/comments";
+        Long postId = 1L;
+        String requestBody = objectMapper.writeValueAsString(new ContentRequest("test comment"));
+        CommentResponse commentResponse = CommentResponse.builder()
+            .id(1L)
+            .authorName("kevin")
+            .content("test comment")
+            .isLiked(false)
+            .build();
+        String responseBody = objectMapper.writeValueAsString(commentResponse);
+
+        // mock
         given(oAuthService.validateToken(anyString()))
             .willReturn(true);
         given(oAuthService.findRequestUserByToken(anyString()))
             .willReturn(loginUser);
-
-        String url = "/api/posts/{postId}/comments";
-        CommentResponse commentResponseDto =
-            new CommentResponse(1L, "kevin", "test comment", false);
-
-        String requestBody = objectMapper.writeValueAsString(new ContentRequest("test"));
-        String responseBody = objectMapper.writeValueAsString(commentResponseDto);
         given(postService.addComment(any(CommentRequest.class)))
-            .willReturn(commentResponseDto);
+            .willReturn(commentResponse);
 
-        ResultActions perform = addCommentApi(url, requestBody)
+        // when
+        ResultActions response = addCommentApi(url, postId, requestBody);
+
+        // then
+        response
             .andExpect(status().isOk())
             .andExpect(content().string(responseBody));
 
         verify(postService, times(1)).addComment(any(CommentRequest.class));
 
-        perform.andDo(document("comment-post",
+        // restdocs
+        response.andDo(document("comment-post",
             getDocumentRequest(),
             getDocumentResponse(),
             requestHeaders(
@@ -235,26 +245,34 @@ class PostControllerTest {
         ));
     }
 
-    @DisplayName("특정 Post에 댓글 등록 실패한다. - 빈 댓글인 경우.")
+    @DisplayName("특정 Post에 댓글 등록 실패한다. - 빈 Comment인 경우.")
     @Test
     void addComment_InValidContent_ExceptionThrown() throws Exception {
+        // given
         LoginUser loginUser = new LoginUser("kevin", "token");
+        String url = "/api/posts/{postId}/comments";
+        Long postId = 1L;
+        String requestBody = objectMapper.writeValueAsString("");
+
+        // mock
         given(oAuthService.validateToken(anyString()))
             .willReturn(true);
         given(oAuthService.findRequestUserByToken(anyString()))
             .willReturn(loginUser);
-
-        String url = "/api/posts/{postId}/comments";
-        String requestBody = objectMapper.writeValueAsString("");
         given(postService.addComment(any(CommentRequest.class)))
             .willThrow(new CommentFormatException());
 
-        ResultActions perform = addCommentApi(url, requestBody)
+        // when
+        ResultActions response = addCommentApi(url, postId, requestBody);
+
+        // then
+        response
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("errorCode").value("F0001"));
         verify(postService, never()).addComment(any(CommentRequest.class));
 
-        perform.andDo(document("comment-post-emptyContent",
+        // restdocs
+        response.andDo(document("comment-post-emptyContent",
             getDocumentRequest(),
             getDocumentResponse(),
             requestHeaders(
@@ -269,8 +287,8 @@ class PostControllerTest {
         ));
     }
 
-    private ResultActions addCommentApi(String url, String requestBody) throws Exception {
-        return mockMvc.perform(post(url, 1)
+    private ResultActions addCommentApi(String url, Long postId, String requestBody) throws Exception {
+        return mockMvc.perform(post(url, postId)
             .header("Authorization", "Bearer test")
             .contentType(MediaType.APPLICATION_JSON)
             .content(requestBody));

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/domain/UserTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/domain/UserTest.java
@@ -16,14 +16,17 @@ class UserTest {
     @DisplayName("User가 특정 Post에 Comment를 추가한다.")
     @Test
     void addComment_Valid_RegistrationSuccess() {
+        // given
         Post post = new Post(null, null, null, null, null, new Comments(), new ArrayList<>(), null);
         Comment comment = new Comment("test comment.");
         User user = new User(null, null, null);
 
+        // when
         user.addComment(post, comment);
-        List<Comment> comments = post.getComments();
 
+        // then
+        List<Comment> comments = post.getComments();
         assertThat(comments).hasSize(1);
-        assertThat(comments.get(0).getUser()).isEqualTo(user);
+        assertThat(comments.get(0).getUser()).isSameAs(user);
     }
 }


### PR DESCRIPTION
# 댓글

<br>

## 프로덕션 수정사항

* `PostService.addComment` 에 `flush` 제거.
  * `PostService` `EntityManager` 필드 제거.
* 연간관계 도움 메서드 부분
  * 변경 전: `User.addComment`에서 User-Comment, Post-Comment의 관계를 이어줌.
  * 변경 후: `User.addComment`에선 User-Comment만, `Post.addComment`에서 Post-Comment를 이어줌.

<br>

## 고민거리

* 댓글에 경우 `Post`쪽 테스트 코드를 바탕으로 해야하는데, `Post`관련 테스트 코드를 수정하려니 너무 큰 작업이다.
  * 예를들어, `Post` 생성하는 것에 빌더 패턴도 없고, 전체적으로 수정해야 할 사항이 보인다.
  * 이 부분은 `Post` 테스트 리팩토링이 머지되고, `Comment` 부분을 수정하여 머지시켜야 좋을 듯 하다.
* `PostService` 통합 테스트에서 `@SpringBootTest` 대신 `@DataJpaTest` 사용하는 것이 더 좋아 보인다.
  * `TestEntityManager`를 사용하여 테스트하여야 하는데 못하고 있음.
  *  토론하여 Post쪽 테스트 리팩토링이 머지되는대로 수정할 계획.

<br>

## 단위 테스트

<br>

### Domain, Infrastructure

* `Comments`
  * 성공 - 100자 이하의 댓글을 생성할 수 있다.
  * 실패 - 100자 초과의 댓글을 생성할 수 없다.
  * 실패 - 댓글은 null이거나 빈 문자열(공백만 있는 문자열 포함)이면 생성할 수 없다.
* `PostRepository`
  * 기타 - Post에 Comment를 추가하면 Comment가 자동 영속화된다. (cascade)
* `User`
  * 성공 - User가 특정 Post에 Comment를 추가한다.

<br>

### Slice

* `PostService`
  * 성공 - 게시물에 댓글을 정상 등록한다.
  * 실패 - 게시물에 빈 댓글을 등록할 수 없다.
  * 실패 - 존재하지 않는 게시글에 댓글을 등록할 수 없다.
  * 실패 - 존재하지 않는 유저는 댓글을 등록할 수 없다.
* `PostController`
  * 성공 - 특정 Post에 Comment을 추가한다.
  * 실패 - 특정 Post에 댓글 등록 실패한다. - 빈 댓글인 경우.

<br>

## 통합 테스트

* `PostService`
  * 성공 - 게시물에 댓글을 정상 등록한다.
  * 실패 - 게시물에 빈 댓글은 등록할 수 없다.
  * 실패 - 존재하지 않는 게시글에 댓글을 등록할 수 없다.
  * 실패 - 존재하지 않는 유저는 댓글을 등록할 수 없다.

<br>

## 인수 테스트

* `PostAcceptanceTest`
  * 성공 - 사용자는 댓글을 등록할 수 있다.
  * 실패 - 게스트는 댓글을 등록할 수 없다. (Authorization Token O)
  * 실패 - 게스트는 댓글을 등록할 수 없다. (Authorization Token X)
  * 실패 - 존재하지 않는 게시물에 댓글을 등록할 수 없다.
  * 실패 - 빈 댓글 내용인 경우 예외가 발생한다.
  * 실패 - 댓글 내용이 100자 초과인 경우 예외가 발생한다.

<br>

Close #246