### PR TITLE
[#221, #225] 프로필 피드 클릭시 유저 피드 페이지로 이동

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ const App = () => {
   return (
     <BrowserRouter>
       <Switch>
-        <Route exact path={[PAGE_URL.HOME, PAGE_URL.PROFILE, PAGE_URL.MY_PROFILE]}>
+        <Route exact path={[PAGE_URL.HOME, PAGE_URL.PROFILE, PAGE_URL.MY_PROFILE, PAGE_URL.USER_FEED]}>
           <NavigationHeader />
         </Route>
         <Route path={PAGE_URL.ADD_POST}>
@@ -27,10 +27,10 @@ const App = () => {
         <Route exact path={[PAGE_URL.HOME, PAGE_URL.HOME_FEED]}>
           <HomeFeedPage />
         </Route>
-        <Route exact path={PAGE_URL.USER_FEED("swon3210")}>
+        <Route exact path={PAGE_URL.USER_FEED}>
           <UserFeedPage />
         </Route>
-        <Route exact path={PAGE_URL.TAG_FEED("Javascript")}>
+        <Route exact path={PAGE_URL.TAG_FEED_BASE}>
           <TagFeedPage />
         </Route>
         <Route exact path={PAGE_URL.LOGIN}>

--- a/frontend/src/components/@layout/NavigationHeader/NavigationHeader.style.ts
+++ b/frontend/src/components/@layout/NavigationHeader/NavigationHeader.style.ts
@@ -5,13 +5,18 @@ import { Header } from "../../@styled/layout";
 export const Container = styled(Header)<React.CSSProperties>`
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  height: fit-content;
   padding: 1.0625rem 1.375rem;
 `;
 
-export const HomeLink = styled(Link)``;
+export const HomeLink = styled(Link)`
+  height: fit-content;
+`;
 
 export const Navigation = styled.nav`
   display: flex;
+  align-items: center;
 `;
 
 export const NavigationItem = styled(Link)`

--- a/frontend/src/components/@layout/NavigationHeader/NavigationHeader.tsx
+++ b/frontend/src/components/@layout/NavigationHeader/NavigationHeader.tsx
@@ -47,8 +47,8 @@ const NavigationHeader = () => {
       {isLoggedIn ? (
         <FlexWrapper>
           <AuthenticatedNavigation />
-          <Button kind="roundedInline" onClick={handleLogoutButtonClick}>
-            Logout
+          <Button kind="roundedInline" padding="0.6rem" onClick={handleLogoutButtonClick}>
+            로그아웃
           </Button>
         </FlexWrapper>
       ) : (

--- a/frontend/src/components/@shared/ImageSlider/ImageSlider.tsx
+++ b/frontend/src/components/@shared/ImageSlider/ImageSlider.tsx
@@ -7,11 +7,12 @@ import { Container, ImageList, ImageListSlider, Indicator, SlideButton } from ".
 
 export interface Props extends React.CSSProperties {
   imageUrls: string[];
+  slideButtonKind: "in-box" | "stick-out";
 }
 
 const SLIDE_THROTTLE_DELAY = 800;
 
-const ImageSlider = ({ imageUrls, width }: Props) => {
+const ImageSlider = ({ imageUrls, width, slideButtonKind }: Props) => {
   const [imageIndex, setImageIndex] = useState(0);
   const [isFirstImage, setIsFirstImage] = useState(true);
   const [isLastImage, setIsLastImage] = useState(false);

--- a/frontend/src/components/Feed/Feed.tsx
+++ b/frontend/src/components/Feed/Feed.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { forwardRef, useContext } from "react";
 import { Post } from "../../@types";
 import { LIMIT } from "../../constants/limits";
 import { FAILURE_MESSAGE } from "../../constants/messages";
@@ -57,7 +57,7 @@ const Feed = ({ posts }: Props) => {
   return (
     <Container>
       {posts?.map((post) => (
-        <PostItemWrapper key={post.id}>
+        <PostItemWrapper id={`post${post.id}`} key={post.id}>
           <PostItem
             authorName={post.authorName}
             authorGithubUrl={post.githubRepoUrl}

--- a/frontend/src/components/ProfileFeed/ProfileFeed.tsx
+++ b/frontend/src/components/ProfileFeed/ProfileFeed.tsx
@@ -1,13 +1,16 @@
 import { Link } from "react-router-dom";
+import { PAGE_URL } from "../../constants/urls";
 import useUserFeed from "../../services/hooks/useUserFeed";
 
 import PageLoading from "../@layout/PageLoading/PageLoading";
 import InfiniteScrollContainer from "../@shared/InfiniteScrollContainer/InfiniteScrollContainer";
 import { Container, Empty, Grid, GridItem } from "./ProfileFeed.styled";
 
-export interface Props extends ReturnType<typeof useUserFeed> {}
+export interface Props extends ReturnType<typeof useUserFeed> {
+  username: string;
+}
 
-const ProfileFeed = ({ allPosts, isLoading, isError, isFetchingNextPage, handleIntersect }: Props) => {
+const ProfileFeed = ({ username, allPosts, isLoading, isError, isFetchingNextPage, handleIntersect, data }: Props) => {
   if (isLoading) {
     return (
       <Empty>
@@ -30,7 +33,14 @@ const ProfileFeed = ({ allPosts, isLoading, isError, isFetchingNextPage, handleI
           >
             <Grid>
               {allPosts?.map(({ id, imageUrls, authorName, content }) => (
-                <Link to="" key={id}>
+                <Link
+                  to={{
+                    pathname: PAGE_URL.USER_FEED,
+                    search: `?username=${username}`,
+                    state: { prevData: data, postId: id },
+                  }}
+                  key={id}
+                >
                   <GridItem imageUrl={imageUrls[0]} aria-label={`${authorName}님의 게시물. ${content}`} />
                 </Link>
               ))}

--- a/frontend/src/components/ProfileTabContents/ProfileTabContents.tsx
+++ b/frontend/src/components/ProfileTabContents/ProfileTabContents.tsx
@@ -5,7 +5,7 @@ import ProfileFeed from "../ProfileFeed/ProfileFeed";
 
 export interface Props {
   isMyProfile: boolean;
-  username: string | null;
+  username: string;
   tabIndex: number;
 }
 
@@ -14,7 +14,7 @@ const ProfileTabContents = ({ isMyProfile, username, tabIndex }: Props) => {
   const githubStatisticQueryResult = useGithubStatsQuery(username);
 
   const tabContents = [
-    <ProfileFeed key="profile-feed" {...userFeedProps} />,
+    <ProfileFeed key="profile-feed" username={username} {...userFeedProps} />,
     <GithubStatistics key="github-stats" username={username} githubStatisticQueryResult={githubStatisticQueryResult} />,
   ];
 

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -3,6 +3,11 @@ export const Layout = {
   PAGE_MARGIN_TOP: "4.625rem",
 };
 
+export const LayoutInPx = {
+  HEADER_HEIGHT: 58,
+  PAGE_MARGIN_TOP: 74,
+};
+
 export const Z_INDEX = {
   HIGHEST: 1200,
   HIGH: 900,

--- a/frontend/src/constants/urls.ts
+++ b/frontend/src/constants/urls.ts
@@ -8,8 +8,9 @@ export const URL_PARAMS = {
 export const PAGE_URL = {
   HOME: "/",
   HOME_FEED: "/posts",
-  TAG_FEED: (tag: string) => `/posts?tag=${tag}`,
-  USER_FEED: (username: string) => `/posts?username=${username}`,
+  TAG_FEED_BASE: "/posts/tag",
+  USER_FEED: "/posts/user",
+  TAG_FEED: (tag: string) => `/posts/tag?tag=${tag}`,
   LOGIN: "/login",
   AUTH_PROCESSING: "/auth",
   ADD_POST: "/add-post",

--- a/frontend/src/pages/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/ProfilePage.tsx
@@ -23,7 +23,7 @@ const ProfilePage = ({ isMyProfile }: Props) => {
   const fixedUsername = isMyProfile ? currentUsername : username;
   const tabItems: TabItem[] = tabNames.map((name, index) => ({ name, onTabChange: () => setTabIndex(index) }));
 
-  if (!isMyProfile && !username) return <Redirect to={PAGE_URL.HOME} />;
+  if (!fixedUsername) return <Redirect to={PAGE_URL.HOME} />;
 
   return (
     <Container>

--- a/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
+++ b/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
@@ -1,45 +1,61 @@
-import { Container } from "./UserFeedPage.style";
+import { useRef, useContext, useEffect, useState } from "react";
+
 import Feed from "../../components/Feed/Feed";
-import { useHomeFeedPostsQuery } from "../../services/queries";
 import InfiniteScrollContainer from "../../components/@shared/InfiniteScrollContainer/InfiniteScrollContainer";
 import PageLoading from "../../components/@layout/PageLoading/PageLoading";
-import axios from "axios";
-import { useQueryClient } from "react-query";
-import { useContext } from "react";
+import useUserFeed from "../../services/hooks/useUserFeed";
+import { Container } from "./UserFeedPage.style";
+import { InfiniteData } from "react-query";
+import { Post } from "../../@types";
+import { useLocation } from "react-router-dom";
+
 import UserContext from "../../contexts/UserContext";
-import { QUERY } from "../../constants/queries";
+import { LayoutInPx } from "../../constants/layout";
+
+interface LocationState {
+  prevData?: InfiniteData<Post[]>;
+  postId?: string;
+}
 
 const UserFeedPage = () => {
-  const { data, isLoading, error, isFetching, fetchNextPage } = useHomeFeedPostsQuery();
-  const queryClient = useQueryClient();
-  const { logout } = useContext(UserContext);
+  const [isMountedOnce, setIsMountedOnce] = useState(false);
+  const { currentUsername } = useContext(UserContext);
+  const username = new URLSearchParams(location.search).get("username");
+  const isMyFeed = currentUsername === username;
+  const {
+    state: { prevData, postId },
+  } = useLocation<LocationState>();
+  const { allPosts, handleIntersect, isLoading, isError, isFetchingNextPage } = useUserFeed(
+    isMyFeed,
+    username,
+    prevData
+  );
 
-  const allPosts = data?.pages?.reduce((acc, postPage) => acc.concat(postPage), []);
+  useEffect(() => {
+    if (!isMountedOnce) {
+      setIsMountedOnce(true);
 
-  const handlePostsEndIntersect = () => {
-    fetchNextPage();
-  };
-
-  if (error) {
-    if (axios.isAxiosError(error)) {
-      const { status } = error.response ?? {};
-
-      if (status === 401) {
-        logout();
-        queryClient.refetchQueries(QUERY.GET_HOME_FEED_POSTS, { active: true });
-      }
+      return;
     }
 
-    return <div>에러!!</div>;
+    const $targetPost = document.querySelector(`#post${postId}`);
+
+    if ($targetPost && $targetPost instanceof HTMLElement) {
+      window.scrollTo(0, $targetPost.offsetTop - LayoutInPx.HEADER_HEIGHT);
+    }
+  }, [postId, isMountedOnce]);
+
+  if (isLoading) {
+    return <PageLoading />;
   }
 
-  if (isLoading || !allPosts) {
-    return <PageLoading />;
+  if (isError) {
+    return <div>피드를 가져올 수 없습니다.</div>;
   }
 
   return (
     <Container>
-      <InfiniteScrollContainer isLoaderShown={isFetching} onIntersect={handlePostsEndIntersect}>
+      <InfiniteScrollContainer isLoaderShown={isFetchingNextPage} onIntersect={handleIntersect}>
         <Feed posts={allPosts} />
       </InfiniteScrollContainer>
     </Container>

--- a/frontend/src/services/queries/posts.ts
+++ b/frontend/src/services/queries/posts.ts
@@ -29,7 +29,9 @@ const userPostsQueryFunction: QueryFunction<Post[]> = async ({ queryKey, pagePar
 
     return await requestGetMyFeedPosts(pageParam, accessToken);
   } else {
-    return await requestGetUserFeedPosts(username as string, pageParam, accessToken);
+    if (!username) throw Error("no username");
+
+    return await requestGetUserFeedPosts(username, pageParam, accessToken);
   }
 };
 


### PR DESCRIPTION
## 상세 내용
- 프로필 하단 피드에서 썸네일을 클릭하면 유저 피드 페이지로 이동하고 해당하는 게시물로 anchor한다.

<br/>

## 기타
- header에서 height가 큰 요소들의 레이아웃이 깨지는 버그 해결 (로그아웃 버튼 레이아웃)

<br/>

Close #225 
