### PR TITLE
[#267] 프로필 수정 기능을 구현

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -5,11 +5,15 @@ import com.woowacourse.pickgit.authentication.presentation.AuthenticationPrincip
 import com.woowacourse.pickgit.authentication.presentation.interceptor.AuthenticationInterceptor;
 import com.woowacourse.pickgit.authentication.presentation.interceptor.IgnoreAuthenticationInterceptor;
 import com.woowacourse.pickgit.authentication.presentation.interceptor.PathMatchInterceptor;
+import java.util.Arrays;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -52,7 +56,7 @@ public class OAuthConfiguration implements WebMvcConfigurer {
             .addPathPatterns("/api/posts", HttpMethod.POST)
             .addPathPatterns("/api/posts/*/likes", HttpMethod.PUT, HttpMethod.DELETE)
             .addPathPatterns("/api/posts/*/comments", HttpMethod.POST)
-            .addPathPatterns("/api/profiles/me", HttpMethod.GET)
+            .addPathPatterns("/api/profiles/me", HttpMethod.GET, HttpMethod.POST)
             .addPathPatterns("/api/profiles/*/followings", HttpMethod.POST, HttpMethod.DELETE);
 
         HandlerInterceptor ignoreAuthenticationInterceptor = new PathMatchInterceptor(ignoreAuthenticationInterceptor())

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/PickGitStorage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/PickGitStorage.java
@@ -2,8 +2,11 @@ package com.woowacourse.pickgit.post.domain;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 public interface PickGitStorage {
 
     List<String> store(List<File> files, String userName);
+
+    Optional<String> store(File file, String userName);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
@@ -3,6 +3,7 @@ package com.woowacourse.pickgit.post.infrastructure;
 import com.woowacourse.pickgit.post.domain.PickGitStorage;
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.FileSystemResource;
@@ -33,6 +34,19 @@ public class S3Storage implements PickGitStorage {
             .getBody();
 
         return response.getUrls();
+    }
+
+    @Override
+    public Optional<String> store(File file, String userName) {
+        List<String> imageUrls = restClient
+            .postForEntity(s3ProxyUrl, createBody(List.of(file), userName), StorageDto.class)
+            .getBody()
+            .getUrls();
+
+        if (imageUrls.size() == 0) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(imageUrls.get(0));
     }
 
     private MultiValueMap<String, Object> createBody(

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
@@ -43,9 +43,6 @@ public class S3Storage implements PickGitStorage {
             .getBody()
             .getUrls();
 
-        if (imageUrls.size() == 0) {
-            return Optional.empty();
-        }
         return Optional.ofNullable(imageUrls.get(0));
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -130,10 +130,10 @@ public class UserService {
         String userImageUrl = user.getImage();
         if (doesContainProfileImage(requestDto.getImage())) {
             userImageUrl = saveImageAndGetUrl(requestDto.getImage(), user.getName());
-            user.changeProfileImage(userImageUrl);
+            user.updateProfileImage(userImageUrl);
         }
 
-        user.changeDescription(requestDto.getDecription());
+        user.updateDescription(requestDto.getDecription());
 
         return new ProfileEditResponseDto(userImageUrl, requestDto.getDecription());
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -3,11 +3,15 @@ package com.woowacourse.pickgit.user.application;
 import static java.util.stream.Collectors.toList;
 
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
 import com.woowacourse.pickgit.exception.user.InvalidUserException;
 import com.woowacourse.pickgit.exception.user.SameSourceTargetUserException;
+import com.woowacourse.pickgit.post.domain.PickGitStorage;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.domain.Contribution;
 import com.woowacourse.pickgit.user.domain.PlatformContributionCalculator;
@@ -19,23 +23,33 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PickGitStorage pickGitStorage;
     private final PlatformContributionCalculator platformContributionCalculator;
 
     public UserService(
         UserRepository userRepository,
+        PickGitStorage pickGitStorage,
         PlatformContributionCalculator platformContributionCalculator
     ) {
         this.userRepository = userRepository;
+        this.pickGitStorage = pickGitStorage;
         this.platformContributionCalculator = platformContributionCalculator;
     }
+
 
     @Transactional(readOnly = true)
     public UserProfileResponseDto getMyUserProfile(AuthUserRequestDto requestDto) {
@@ -108,6 +122,58 @@ public class UserService {
             .issuesCount(contribution.getIssuesCount())
             .reposCount(contribution.getReposCount())
             .build();
+    }
+
+    public ProfileEditResponseDto editProfile(AppUser appUser, ProfileEditRequestDto requestDto) {
+        User user = findUserByName(appUser.getUsername());
+
+        String userImageUrl = user.getImage();
+        if (doesContainProfileImage(requestDto.getImage())) {
+            userImageUrl = saveImageAndGetUrl(requestDto.getImage(), user.getName());
+            user.changeProfileImage(userImageUrl);
+        }
+
+        user.changeDescription(requestDto.getDecription());
+
+        return new ProfileEditResponseDto(userImageUrl, requestDto.getDecription());
+    }
+
+    private boolean doesContainProfileImage(MultipartFile image) {
+        if (Objects.isNull(image)) {
+            return false;
+        }
+        return !Objects.requireNonNull(image.getOriginalFilename()).isBlank();
+    }
+
+    private String saveImageAndGetUrl(MultipartFile image, String username) {
+        File file = fileFrom(image);
+
+        return saveImageAndGetUrl(file, username);
+    }
+
+    private File fileFrom(MultipartFile image) {
+        try {
+            return image.getResource().getFile();
+        } catch (IOException e) {
+            return tryCreateTempFile(image);
+        }
+    }
+
+    private File tryCreateTempFile(MultipartFile multipartFile) {
+        try {
+            Path tempFile = Files.createTempFile(null, null);
+            Files.write(tempFile, multipartFile.getBytes());
+
+            return tempFile.toFile();
+        } catch (IOException ioException) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+
+    private String saveImageAndGetUrl(File file, String username) {
+        return pickGitStorage
+            .store(file, username)
+            .orElseThrow(PlatformHttpErrorException::new);
     }
 
     public FollowResponseDto followUser(AuthUserRequestDto requestDto, String targetName) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/ProfileEditRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/ProfileEditRequestDto.java
@@ -1,0 +1,31 @@
+package com.woowacourse.pickgit.user.application.dto.request;
+
+import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
+
+@Builder
+public class ProfileEditRequestDto {
+
+    private MultipartFile image;
+    private String decription;
+
+    private ProfileEditRequestDto() {
+    }
+
+    public ProfileEditRequestDto(MultipartFile image, String decription) {
+        this.image = image;
+        this.decription = decription;
+    }
+
+    public MultipartFile getImage() {
+        return image;
+    }
+
+    public String getImageOriginalFileName() {
+        return image.getOriginalFilename();
+    }
+
+    public String getDecription() {
+        return decription;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/response/ProfileEditResponseDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/response/ProfileEditResponseDto.java
@@ -1,0 +1,26 @@
+package com.woowacourse.pickgit.user.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class ProfileEditResponseDto {
+
+    private String imageUrl;
+    private String description;
+
+    public ProfileEditResponseDto() {
+    }
+
+    public ProfileEditResponseDto(String imageUrl, String description) {
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -61,11 +61,11 @@ public class User {
         this.githubProfile = githubProfile;
     }
 
-    public void changeDescription(String description) {
+    public void updateDescription(String description) {
         this.basicProfile.setDescription(description);
     }
 
-    public void changeProfileImage(String imageUrl) {
+    public void updateProfileImage(String imageUrl) {
         this.basicProfile.setImage(imageUrl);
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -61,6 +61,14 @@ public class User {
         this.githubProfile = githubProfile;
     }
 
+    public void changeDescription(String description) {
+        this.basicProfile.setDescription(description);
+    }
+
+    public void changeProfileImage(String imageUrl) {
+        this.basicProfile.setImage(imageUrl);
+    }
+
     public void follow(User target) {
         Follow follow = new Follow(this, target);
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -10,6 +10,7 @@ import com.woowacourse.pickgit.user.application.dto.response.ContributionRespons
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
+import com.woowacourse.pickgit.user.presentation.dto.request.ProfileEditRequest;
 import com.woowacourse.pickgit.user.presentation.dto.response.ContributionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.FollowResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.ProfileEditResponse;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -110,13 +112,12 @@ public class UserController {
     @PostMapping("/me")
     public ResponseEntity<ProfileEditResponse> editProfile(
         @Authenticated AppUser appUser,
-        @RequestParam(value = "image", required = false) MultipartFile image,
-        @RequestParam(value = "description") String description
+        @ModelAttribute ProfileEditRequest request
     ) {
         ProfileEditRequestDto requestDto = ProfileEditRequestDto
             .builder()
-            .image(image)
-            .decription(description)
+            .image(request.getImage())
+            .decription(request.getDescription())
             .build();
         ProfileEditResponseDto responseDto = userService.editProfile(appUser, requestDto);
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -5,11 +5,14 @@ import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.exception.authentication.UnauthorizedException;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.presentation.dto.response.ContributionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.FollowResponse;
+import com.woowacourse.pickgit.user.presentation.dto.response.ProfileEditResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.UserProfileResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -18,7 +21,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/profiles")
@@ -100,6 +105,23 @@ public class UserController {
             userService.followUser(authUserRequestDto, username);
 
         return ResponseEntity.ok(createFollowResponse(followResponseDto));
+    }
+
+    @PostMapping("/me")
+    public ResponseEntity<ProfileEditResponse> editProfile(
+        @Authenticated AppUser appUser,
+        @RequestParam(value = "image", required = false) MultipartFile image,
+        @RequestParam(value = "description") String description
+    ) {
+        ProfileEditResponseDto responseDto = userService
+            .editProfile(appUser, new ProfileEditRequestDto(image, description));
+
+        return ResponseEntity.ok(
+            new ProfileEditResponse(
+                responseDto.getImageUrl(),
+                responseDto.getDescription()
+            )
+        );
     }
 
     @DeleteMapping("/{username}/followings")

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -113,8 +113,12 @@ public class UserController {
         @RequestParam(value = "image", required = false) MultipartFile image,
         @RequestParam(value = "description") String description
     ) {
-        ProfileEditResponseDto responseDto = userService
-            .editProfile(appUser, new ProfileEditRequestDto(image, description));
+        ProfileEditRequestDto requestDto = ProfileEditRequestDto
+            .builder()
+            .image(image)
+            .decription(description)
+            .build();
+        ProfileEditResponseDto responseDto = userService.editProfile(appUser, requestDto);
 
         return ResponseEntity.ok(
             new ProfileEditResponse(

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
@@ -1,0 +1,25 @@
+package com.woowacourse.pickgit.user.presentation.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class ProfileEditRequest {
+
+    private MultipartFile image;
+    private String description;
+
+    public ProfileEditRequest() {
+    }
+
+    public ProfileEditRequest(MultipartFile image, String description) {
+        this.image = image;
+        this.description = description;
+    }
+
+    public MultipartFile getImage() {
+        return image;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
@@ -7,10 +7,12 @@ public class ProfileEditRequest {
     private MultipartFile image;
     private String description;
 
-    public ProfileEditRequest() {
+    private ProfileEditRequest() {
     }
 
-    public ProfileEditRequest(MultipartFile image, String description) {
+    public ProfileEditRequest(
+        MultipartFile image,
+        String description) {
         this.image = image;
         this.description = description;
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileEditRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pickgit.user.presentation.dto.request;
 
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ProfileEditRequest {
@@ -11,8 +12,8 @@ public class ProfileEditRequest {
     }
 
     public ProfileEditRequest(
-        MultipartFile image,
-        String description) {
+        @RequestParam(name = "image", required = false) MultipartFile image,
+        @RequestParam(name = "description") String description) {
         this.image = image;
         this.description = description;
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileEditResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileEditResponse.java
@@ -1,0 +1,23 @@
+package com.woowacourse.pickgit.user.presentation.dto.response;
+
+public class ProfileEditResponse {
+
+    private String imageUrl;
+    private String description;
+
+    public ProfileEditResponse() {
+    }
+
+    public ProfileEditResponse(String imageUrl, String description) {
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileEditResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileEditResponse.java
@@ -5,7 +5,7 @@ public class ProfileEditResponse {
     private String imageUrl;
     private String description;
 
-    public ProfileEditResponse() {
+    private ProfileEditResponse() {
     }
 
     public ProfileEditResponse(String imageUrl, String description) {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
@@ -245,29 +245,6 @@ class UserAcceptanceTest {
         assertThat(response.getDescription()).isEqualTo(description);
     }
 
-    @DisplayName("사용자는 자신의 프로필(한 줄 소개만 포함)을 수정할 수 있다.")
-    @Test
-    void editUserProfile_LoginUserWithDescription_Success() {
-        // given
-        String description = "updated profile description";
-
-        // when
-        ProfileEditResponse response = given().log().all()
-            .auth().oauth2(loginUserAccessToken)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-            .formParams("description", description)
-            .multiPart("image", "")
-            .when()
-            .post("/api/profiles/me")
-            .then().log().all()
-            .extract()
-            .as(ProfileEditResponse.class);
-
-        // then
-        assertThat(response.getImageUrl()).isEqualTo(loginUser.getImage());
-        assertThat(response.getDescription()).isEqualTo(description);
-    }
-
     @DisplayName("게스트는 프로필을 수정할 수 없다.")
     @Test
     void editUserProfile_GuestUser_Fail() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
@@ -252,7 +252,6 @@ class UserAcceptanceTest {
         String description = "updated profile description";
 
         // when
-
         ProfileEditResponse response = given().log().all()
             .auth().oauth2(loginUserAccessToken)
             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pickgit.acceptance.user;
 
+import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.Mockito.when;
@@ -7,27 +8,24 @@ import static org.mockito.Mockito.when;
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
+import com.woowacourse.pickgit.common.factory.FileFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.dto.ApiErrorResponse;
-<<<<<<< HEAD
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
-=======
-import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
->>>>>>> 1102161... refactor: 프론트측과 협의한 부분 리팩토링
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.presentation.dto.response.ContributionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.FollowResponse;
-import com.woowacourse.pickgit.user.presentation.dto.response.SearchResponse;
+import com.woowacourse.pickgit.user.presentation.dto.response.ProfileEditResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.UserProfileResponse;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.io.File;
 import java.util.List;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -221,6 +219,77 @@ class UserAcceptanceTest {
 
         // then
         assertThat(response.getErrorCode()).isEqualTo("U0001");
+    }
+
+    @DisplayName("사용자는 자신의 프로필(이미지, 한 줄 소개 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_LoginUserWithImageAndDescription_Success() {
+        // given
+        String description = "updated profile description";
+        File imageFile = FileFactory.getTestImage1File();
+
+        // when
+        ProfileEditResponse response = given().log().all()
+            .auth().oauth2(loginUserAccessToken)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .formParams("description", description)
+            .multiPart("image", imageFile)
+            .when()
+            .post("/api/profiles/me")
+            .then().log().all()
+            .extract()
+            .as(ProfileEditResponse.class);
+
+        // then
+        assertThat(response.getImageUrl()).isNotBlank();
+        assertThat(response.getDescription()).isEqualTo(description);
+    }
+
+    @DisplayName("사용자는 자신의 프로필(한 줄 소개만 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_LoginUserWithDescription_Success() {
+        // given
+        String description = "updated profile description";
+
+        // when
+
+        ProfileEditResponse response = given().log().all()
+            .auth().oauth2(loginUserAccessToken)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .formParams("description", description)
+            .multiPart("image", "")
+            .when()
+            .post("/api/profiles/me")
+            .then().log().all()
+            .extract()
+            .as(ProfileEditResponse.class);
+
+        // then
+        assertThat(response.getImageUrl()).isEqualTo(loginUser.getImage());
+        assertThat(response.getDescription()).isEqualTo(description);
+    }
+
+    @DisplayName("게스트는 프로필을 수정할 수 없다.")
+    @Test
+    void editUserProfile_GuestUser_Fail() {
+        // given
+        String description = "updated profile description";
+
+        // when
+        ApiErrorResponse response = given().log().all()
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .formParams("description", description)
+            .multiPart("image", "")
+            .when()
+            .post("/api/profiles/me")
+            .then().log().all()
+            .extract()
+            .as(ApiErrorResponse.class);
+
+        // then
+        assertThat(response)
+            .extracting("errorCode")
+            .isEqualTo("A0001");
     }
 
     @DisplayName("source 유저는 target 유저를 팔로우할 수 있다.")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/FileFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/FileFactory.java
@@ -4,12 +4,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Objects;
 import org.apache.http.entity.ContentType;
-import org.mockito.Mock;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 
 public class FileFactory {
 
@@ -24,7 +21,7 @@ public class FileFactory {
         return createImageFile("testImage2.png");
     }
 
-    public static MockMultipartFile getEmptyTestImage() { return createEmptyImageFile();}
+    public static MockMultipartFile getEmptyTestFile() { return createEmptyImageFile();}
 
     public static File getTestImage1File() {
         return createFile("testImage1.png");

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/FileFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/FileFactory.java
@@ -4,9 +4,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 import org.apache.http.entity.ContentType;
+import org.mockito.Mock;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 public class FileFactory {
 
@@ -20,6 +23,8 @@ public class FileFactory {
     public static MockMultipartFile getTestImage2() {
         return createImageFile("testImage2.png");
     }
+
+    public static MockMultipartFile getEmptyTestImage() { return createEmptyImageFile();}
 
     public static File getTestImage1File() {
         return createFile("testImage1.png");
@@ -42,6 +47,15 @@ public class FileFactory {
         } catch (IOException e) {
             throw new RuntimeException();
         }
+    }
+
+    private static MockMultipartFile createEmptyImageFile() {
+        return new MockMultipartFile(
+            "images",
+            "",
+            null,
+            new byte[] {}
+        );
     }
 
     private static File createFile(String fileName) {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.woowacourse.pickgit.post.domain.PickGitStorage;
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 public class MockPickGitStorage implements PickGitStorage {
 
@@ -13,5 +14,10 @@ public class MockPickGitStorage implements PickGitStorage {
         return files.stream()
             .map(File::getName)
             .collect(toList());
+    }
+
+    @Override
+    public Optional<String> store(File file, String userName) {
+        return Optional.ofNullable(file.getName());
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -230,7 +230,7 @@ class UserServiceIntegrationTest {
         // when
         ProfileEditRequestDto requestDto = ProfileEditRequestDto
             .builder()
-            .image(FileFactory.getEmptyTestImage())
+            .image(FileFactory.getEmptyTestFile())
             .decription(updatedDescription)
             .build();
         ProfileEditResponseDto responseDto =

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -7,16 +7,20 @@ import static org.assertj.core.groups.Tuple.tuple;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
+import com.woowacourse.pickgit.common.factory.FileFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.user.DuplicateFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidUserException;
+import com.woowacourse.pickgit.post.domain.PickGitStorage;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.domain.User;
@@ -25,8 +29,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
@@ -46,6 +48,9 @@ class UserServiceIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private PickGitStorage pickGitStorage;
 
     @DisplayName("사용자는 자신의 프로필을 조회할 수 있다.")
     @Test
@@ -186,6 +191,54 @@ class UserServiceIntegrationTest {
             .hasFieldOrPropertyWithValue("errorCode", "U0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST)
             .hasMessage("유효하지 않은 유저입니다.");
+    }
+
+    @DisplayName("자신의 프로필(이미지, 한 줄 소개 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_WithImageAndDescription_Success() {
+        // given
+        String updatedDescription = "updated description";
+        LoginUser loginUser = new LoginUser("testUser", "token");
+        User user = UserFactory.user("testUser");
+
+        userRepository.save(user);
+
+        // when
+        ProfileEditRequestDto requestDto = ProfileEditRequestDto
+            .builder()
+            .image(FileFactory.getTestImage1())
+            .decription(updatedDescription)
+            .build();
+        ProfileEditResponseDto responseDto =
+            userService.editProfile(loginUser, requestDto);
+
+        // then
+        assertThat(responseDto.getImageUrl()).isNotBlank();
+        assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
+    }
+
+    @DisplayName("자신의 프로필(한 줄 소개만 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_WithDescription_Success() {
+        // given
+        String updatedDescription = "updated description";
+        LoginUser loginUser = new LoginUser("testUser", "token");
+        User user = UserFactory.user("testUser");
+
+        userRepository.save(user);
+
+        // when
+        ProfileEditRequestDto requestDto = ProfileEditRequestDto
+            .builder()
+            .image(FileFactory.getEmptyTestImage())
+            .decription(updatedDescription)
+            .build();
+        ProfileEditResponseDto responseDto =
+            userService.editProfile(loginUser, requestDto);
+
+        // then
+        assertThat(responseDto.getImageUrl()).isEqualTo(user.getImage());
+        assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
     }
 
     @DisplayName("source 유저는 target 유저를 팔로우할 수 있다.")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -334,13 +334,7 @@ class UserServiceIntegrationTest {
         searchedUsers.forEach(user -> userRepository.save(user));
 
         // when
-        User source = userRepository.findByBasicProfile_Name(loginUser.getName())
-            .orElseThrow();
-        User target = userRepository.findByBasicProfile_Name(searchedUsers.get(0).getName())
-            .orElseThrow();
-        source.follow(target);
-
-        userRepository.flush();
+        userService.followUser(new AuthUserRequestDto(loginUser.getName()), searchedUsers.get(0).getName());
 
         List<UserSearchResponseDto> searchResult =
             userService.searchUser(new LoginUser(loginUser.getName(), "token"),

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -31,6 +31,7 @@ import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -3,12 +3,10 @@ package com.woowacourse.pickgit.unit.user.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
@@ -33,7 +31,6 @@ import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import java.io.File;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -263,7 +260,7 @@ class UserServiceTest {
         // when
         ProfileEditRequestDto requestDto = ProfileEditRequestDto
             .builder()
-            .image(FileFactory.getEmptyTestImage())
+            .image(FileFactory.getEmptyTestFile())
             .decription(updatedDescription)
             .build();
         ProfileEditResponseDto responseDto = userService.editProfile(loginUser, requestDto);

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -3,22 +3,28 @@ package com.woowacourse.pickgit.unit.user.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
+import com.woowacourse.pickgit.common.factory.FileFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.exception.user.DuplicateFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidUserException;
+import com.woowacourse.pickgit.post.domain.PickGitStorage;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.domain.Contribution;
 import com.woowacourse.pickgit.user.domain.PlatformContributionCalculator;
@@ -26,6 +32,7 @@ import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
+import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -49,6 +57,9 @@ class UserServiceTest {
 
     @Mock
     private PlatformContributionCalculator platformContributionCalculator;
+
+    @Mock
+    private PickGitStorage pickGitStorage;
 
     @DisplayName("사용자는 내 이름으로 내 프로필을 조회할 수 있다.")
     @Test
@@ -204,6 +215,64 @@ class UserServiceTest {
         // then
         verify(userRepository, times(1))
             .findByBasicProfile_Name(anyString());
+    }
+
+    @DisplayName("자신의 프로필(이미지, 한 줄 소개 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_WithImageAndDescription_Success() {
+        // given
+        LoginUser loginUser = new LoginUser("testUser", "token");
+        MultipartFile image = FileFactory.getTestImage1();
+        String updatedDescription = "updated description";
+
+        // mock
+        given(userRepository.findByBasicProfile_Name("testUser"))
+            .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
+        given(pickGitStorage.store(any(File.class), anyString()))
+            .willReturn(Optional.ofNullable(image.getName()));
+
+        // when
+        ProfileEditRequestDto requestDto = ProfileEditRequestDto
+            .builder()
+            .image(image)
+            .decription(updatedDescription)
+            .build();
+        ProfileEditResponseDto responseDto = userService.editProfile(loginUser, requestDto);
+
+        // then
+        assertThat(responseDto.getImageUrl()).isEqualTo(image.getName());
+        assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name("testUser");
+        verify(pickGitStorage, times(1))
+            .store(any(File.class), anyString());
+    }
+
+    @DisplayName("자신의 프로필(한 줄 소개만 포함)을 수정할 수 있다.")
+    @Test
+    void editUserProfile_WithDescrption_Success() {
+        // given
+        LoginUser loginUser = new LoginUser("testUser", "token");
+        User user = UserFactory.user(1L, "testUser");
+        String updatedDescription = "updated descrption";
+
+        // mock
+        given(userRepository.findByBasicProfile_Name("testUser"))
+            .willReturn(Optional.of(user));
+
+        // when
+        ProfileEditRequestDto requestDto = ProfileEditRequestDto
+            .builder()
+            .image(FileFactory.getEmptyTestImage())
+            .decription(updatedDescription)
+            .build();
+        ProfileEditResponseDto responseDto = userService.editProfile(loginUser, requestDto);
+
+        // then
+        assertThat(responseDto.getImageUrl()).isEqualTo(user.getImage());
+        assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name(user.getName());
     }
 
     @DisplayName("source 유저는 target 유저를 팔로우할 수 있다.")


### PR DESCRIPTION
멀티 파트부분이랑 자바 File 관련된 개념이 익숙하지 않아서 삽질을 좀 많이 했네요ㅠ

늦어서 죄송합니다 :)

<br>

## 상세 내용
- 프로필 수정 기능을 구현

<br/>

## 기타
- 현재 S3 Storage와 Github API에 요청하는 부분들에 있어서 중복된 부분들이 많은데요.. 논의 후 패키지를 분리시키던지 해야할 듯 합니다!
  - 일단 너잘과 상의 결과 `User`에서만 사용하는 S3관련 인터페이스를 빼진 않기로 했습니다. 그래서 일단 기존의 `Post` 패키지에 있는 것을 가져다가 쓰도록 구현되어있습니다. (추후 리팩토링 필요해보입니다.)

<br/>

Close #267
