### PR TITLE
[#292] restDocs 필드명 수정 및 Boolean으로 변경

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/response/LikeResponseDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/response/LikeResponseDto.java
@@ -3,7 +3,7 @@ package com.woowacourse.pickgit.post.application.dto.response;
 public class LikeResponseDto {
 
     private int likesCount;
-    private boolean liked;
+    private Boolean liked;
 
     private LikeResponseDto() {
     }
@@ -17,7 +17,7 @@ public class LikeResponseDto {
         return likesCount;
     }
 
-    public boolean isLiked() {
+    public Boolean getLiked() {
         return liked;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
@@ -147,7 +147,7 @@ public class PostController {
         LikeResponseDto likeResponseDto = postService.like(user, postId);
 
         LikeResponse likeResponse =
-            new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.isLiked());
+            new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.getLiked());
 
         return ResponseEntity.ok(likeResponse);
     }
@@ -161,7 +161,7 @@ public class PostController {
         LikeResponseDto likeResponseDto = postService.unlike(user, postId);
 
         LikeResponse likeResponse =
-            new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.isLiked());
+            new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.getLiked());
 
         return ResponseEntity.ok(likeResponse);
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/response/LikeResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/response/LikeResponse.java
@@ -3,7 +3,7 @@ package com.woowacourse.pickgit.post.presentation.dto.response;
 public class LikeResponse {
 
     private int likesCount;
-    private boolean liked;
+    private Boolean liked;
 
     private LikeResponse() {
     }
@@ -17,7 +17,7 @@ public class LikeResponse {
         return likesCount;
     }
 
-    public boolean isLiked() {
+    public Boolean getLiked() {
         return liked;
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
@@ -272,6 +272,7 @@ class PostAcceptanceTest {
             });
 
         assertThat(response).hasSize(3);
+        assertThat(response.get(0).getLiked()).isFalse();
     }
 
     @DisplayName("로그인 상태에서 다른 유저 피드 조회가 가능하다.")
@@ -293,6 +294,7 @@ class PostAcceptanceTest {
             });
 
         assertThat(response).hasSize(3);
+        assertThat(response.get(0).getLiked()).isNull();
     }
 
     @DisplayName("게스트는 게시글을 등록할 수 없다. - 유효하지 않은 토큰이 있는 경우 (Authorization header O)")
@@ -524,7 +526,7 @@ class PostAcceptanceTest {
 
         // then
         assertThat(response.getLikesCount()).isEqualTo(1);
-        assertThat(response.isLiked()).isTrue();
+        assertThat(response.getLiked()).isTrue();
     }
 
     @DisplayName("로그인 사용자는 게시물을 좋아요 취소 할 수 있다. - 성공")
@@ -548,7 +550,7 @@ class PostAcceptanceTest {
             });
 
         assertThat(likePostResponse.getLikesCount()).isEqualTo(1);
-        assertThat(likePostResponse.isLiked()).isTrue();
+        assertThat(likePostResponse.getLiked()).isTrue();
 
         // when
         LikeResponse unlikePostResponse = given().log().all()
@@ -563,7 +565,7 @@ class PostAcceptanceTest {
 
         // then
         assertThat(unlikePostResponse.getLikesCount()).isEqualTo(0);
-        assertThat(unlikePostResponse.isLiked()).isFalse();
+        assertThat(unlikePostResponse.getLiked()).isFalse();
     }
 
     @DisplayName("게스트는 게시물을 좋아요 할 수 없다. - 실패")
@@ -633,7 +635,7 @@ class PostAcceptanceTest {
             });
 
         assertThat(likePostResponse.getLikesCount()).isEqualTo(1);
-        assertThat(likePostResponse.isLiked()).isTrue();
+        assertThat(likePostResponse.getLiked()).isTrue();
 
         // when
         DuplicatedLikeException secondLikeResponse = given().log().all()

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
@@ -450,7 +450,7 @@ class PostServiceIntegrationTest {
 
         // then
         assertThat(likeResponseDto.getLikesCount()).isEqualTo(1);
-        assertThat(likeResponseDto.isLiked()).isTrue();
+        assertThat(likeResponseDto.getLiked()).isTrue();
     }
 
     @DisplayName("사용자는 특정 게시물을 좋아요 취소 할 수 있다. - 성공")
@@ -470,7 +470,7 @@ class PostServiceIntegrationTest {
 
         // then
         assertThat(likeResponseDto.getLikesCount()).isEqualTo(0);
-        assertThat(likeResponseDto.isLiked()).isFalse();
+        assertThat(likeResponseDto.getLiked()).isFalse();
     }
 
     @DisplayName("사용자는 이미 좋아요 한 게시물을 좋아요 추가 할 수 없다. - 실패")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest.java
@@ -603,7 +603,7 @@ class PostServiceTest {
 
         // then
         assertThat(likeResponseDto.getLikesCount()).isEqualTo(1);
-        assertThat(likeResponseDto.isLiked()).isTrue();
+        assertThat(likeResponseDto.getLiked()).isTrue();
 
         verify(userRepository, times(1))
             .findByBasicProfile_Name(appUser.getUsername());
@@ -635,7 +635,7 @@ class PostServiceTest {
 
         // then
         assertThat(likeResponseDto.getLikesCount()).isEqualTo(0);
-        assertThat(likeResponseDto.isLiked()).isFalse();
+        assertThat(likeResponseDto.getLiked()).isFalse();
 
         verify(userRepository, times(1))
             .findByBasicProfile_Name(appUser.getUsername());

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
@@ -227,7 +227,7 @@ class PostControllerTest {
                 fieldWithPath("profileImageUrl").type(STRING).description("댓글 작성자 프로필 사진"),
                 fieldWithPath("authorName").type(STRING).description("작성자 이름"),
                 fieldWithPath("content").type(STRING).description("댓글 내용"),
-                fieldWithPath("isLiked").type(BOOLEAN).description("좋아요 여부")
+                fieldWithPath("liked").type(BOOLEAN).description("좋아요 여부")
             )
         ));
     }
@@ -366,8 +366,8 @@ class PostControllerTest {
                     .description("댓글 작성자 프로필 사진"),
                 fieldWithPath("[].comments[].authorName").type(STRING).description("댓글 작성자 이름"),
                 fieldWithPath("[].comments[].content").type(STRING).description("댓글 내용"),
-                fieldWithPath("[].comments[].isLiked").type(BOOLEAN).description("댓글 좋아요 여부"),
-                fieldWithPath("[].isLiked").type(BOOLEAN).description("좋아요 여부")
+                fieldWithPath("[].comments[].liked").type(BOOLEAN).description("댓글 좋아요 여부"),
+                fieldWithPath("[].liked").type(BOOLEAN).description("좋아요 여부")
             )
             )
         );
@@ -420,8 +420,8 @@ class PostControllerTest {
                     .description("댓글 작성자 프로필 사진"),
                 fieldWithPath("[].comments[].authorName").type(STRING).description("댓글 작성자 이름"),
                 fieldWithPath("[].comments[].content").type(STRING).description("댓글 내용"),
-                fieldWithPath("[].comments[].isLiked").type(BOOLEAN).description("댓글 좋아요 여부"),
-                fieldWithPath("[].isLiked").type(BOOLEAN).description("좋아요 여부")
+                fieldWithPath("[].comments[].liked").type(BOOLEAN).description("댓글 좋아요 여부"),
+                fieldWithPath("[].liked").type(BOOLEAN).description("좋아요 여부")
             )
             )
         );
@@ -444,7 +444,7 @@ class PostControllerTest {
 
         String likeResponse =
             objectMapper.writeValueAsString(
-                new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.isLiked())
+                new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.getLiked())
             );
 
         // when
@@ -468,7 +468,7 @@ class PostControllerTest {
                 parameterWithName("postId").description("포스트 id")
             ),
             responseFields(
-                fieldWithPath("likeCount").type(NUMBER).description("게시물 좋아요 개수"),
+                fieldWithPath("likesCount").type(NUMBER).description("게시물 좋아요 개수"),
                 fieldWithPath("liked").type(BOOLEAN).description("게시물 좋아요 여부")
             )
         ));
@@ -498,7 +498,7 @@ class PostControllerTest {
 
         String likeResponse =
             objectMapper.writeValueAsString(
-                new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.isLiked())
+                new LikeResponse(likeResponseDto.getLikesCount(), likeResponseDto.getLiked())
             );
 
         // when
@@ -522,7 +522,7 @@ class PostControllerTest {
                 parameterWithName("postId").description("포스트 id")
             ),
             responseFields(
-                fieldWithPath("likeCount").type(NUMBER).description("게시물 좋아요 개수"),
+                fieldWithPath("likesCount").type(NUMBER).description("게시물 좋아요 개수"),
                 fieldWithPath("liked").type(BOOLEAN).description("게시물 좋아요 여부")
             )
         ));


### PR DESCRIPTION
## 상세 내용
- DTO 필드명을 바꿨으나, restDocs 에서 바꾸지 않은 버그를 해결
- `likeCount` -> `likesCount`
- `isLiked` -> `likes`
- 모든 primitive `boolean` -> `Boolean`으로 변경 
<br/>

Close #292 
