### PR TITLE
[#308] 게시물 수정 버그 해결

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
@@ -63,7 +63,8 @@ public class Post {
     @OneToMany(
         mappedBy = "post",
         fetch = FetchType.LAZY,
-        cascade = {CascadeType.PERSIST, CascadeType.REMOVE}
+        cascade = CascadeType.PERSIST,
+        orphanRemoval = true
     )
     private List<PostTag> postTags = new ArrayList<>();
 


### PR DESCRIPTION
## 상세 내용
- orphanRemoval = true 옵션을 추가했습니다.
- 사용자는 중복되는 태그로 게시물을 수정할 수 없다 테스트도 추가했습니다.

<br/>

Close #308 