### PR TITLE
[#338] github statistics가 로그인 시에만 보이도록 수정

### DIFF
--- a/frontend/src/components/GithubStatistics/GithubStatistics.style.ts
+++ b/frontend/src/components/GithubStatistics/GithubStatistics.style.ts
@@ -28,3 +28,13 @@ export const ContributionGraphWrapper = styled.div`
   width: 100%;
   overflow-x: auto;
 `;
+
+export const Empty = styled.div`
+  width: 100%;
+  height: 23.5625rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;

--- a/frontend/src/components/GithubStatistics/GithubStatistics.tsx
+++ b/frontend/src/components/GithubStatistics/GithubStatistics.tsx
@@ -1,13 +1,21 @@
-import { AxiosError } from "axios";
 import { useContext } from "react";
-import { UseQueryResult } from "react-query";
 import { ThemeContext } from "styled-components";
 
-import { ErrorResponse, GithubStats } from "../../@types";
+import { GithubStats } from "../../@types";
 import { BookIcon, ClockIcon, IssueIcon, PrIcon, StarIcon } from "../../assets/icons";
+import UserContext from "../../contexts/UserContext";
+import useGithubStatistics from "../../services/hooks/useGithubStatistics";
 import PageLoading from "../@layout/PageLoading/PageLoading";
 import CircleIcon from "../@shared/CircleIcon/CircleIcon";
-import { Container, ContributionGraphWrapper, GithubStatsWrapper, Stat } from "./GithubStatistics.style";
+import { Container, ContributionGraphWrapper, GithubStatsWrapper, Stat, Empty } from "./GithubStatistics.style";
+
+const stats: Stats = {
+  stars: { name: "Stars", icon: <StarIcon />, countVariable: "starsCount" },
+  commits: { name: "Commits", icon: <ClockIcon />, countVariable: "commitsCount" },
+  prs: { name: "PRs", icon: <PrIcon />, countVariable: "prsCount" },
+  issues: { name: "Issues", icon: <IssueIcon />, countVariable: "issuesCount" },
+  contributes: { name: "Contributes", icon: <BookIcon />, countVariable: "contributesCount" },
+};
 
 interface Stats {
   [K: string]: {
@@ -19,28 +27,17 @@ interface Stats {
 
 export interface Props {
   username: string | null;
-  githubStatisticQueryResult: UseQueryResult<GithubStats, AxiosError<ErrorResponse>>;
+  githubStatisticQueryResult: ReturnType<typeof useGithubStatistics>;
 }
-
-const stats: Stats = {
-  stars: { name: "Stars", icon: <StarIcon />, countVariable: "starsCount" },
-  commits: { name: "Commits", icon: <ClockIcon />, countVariable: "commitsCount" },
-  prs: { name: "PRs", icon: <PrIcon />, countVariable: "prsCount" },
-  issues: { name: "Issues", icon: <IssueIcon />, countVariable: "issuesCount" },
-  contributes: { name: "Contributes", icon: <BookIcon />, countVariable: "contributesCount" },
-};
 
 const GithubStatistics = ({ username, githubStatisticQueryResult }: Props) => {
   const { color } = useContext(ThemeContext);
-  const { data, isLoading, error } = githubStatisticQueryResult;
-
-  if (isLoading) {
-    return <PageLoading />;
-  }
+  const { isLoggedIn } = useContext(UserContext);
+  const { data, isLoading, isError } = githubStatisticQueryResult;
 
   const GithubStats = () => {
     const Content = () => {
-      if (error) {
+      if (isError) {
         return <div>Github Stats을 표시할 수 없습니다.</div>;
       }
 
@@ -67,6 +64,18 @@ const GithubStatistics = ({ username, githubStatisticQueryResult }: Props) => {
       </>
     );
   };
+
+  if (!isLoggedIn) {
+    return <Empty>로그인 후 이용할 수 있는 서비스입니다.</Empty>;
+  }
+
+  if (isLoading) {
+    return (
+      <Empty>
+        <PageLoading />
+      </Empty>
+    );
+  }
 
   return (
     <Container>

--- a/frontend/src/components/ProfileTabContents/ProfileTabContents.tsx
+++ b/frontend/src/components/ProfileTabContents/ProfileTabContents.tsx
@@ -1,5 +1,5 @@
+import useGithubStatistics from "../../services/hooks/useGithubStatistics";
 import useUserFeed from "../../services/hooks/useUserFeed";
-import { useGithubStatsQuery } from "../../services/queries";
 import GithubStatistics from "../GithubStatistics/GithubStatistics";
 import ProfileFeed from "../ProfileFeed/ProfileFeed";
 
@@ -11,7 +11,7 @@ export interface Props {
 
 const ProfileTabContents = ({ isMyProfile, username, tabIndex }: Props) => {
   const userFeedProps = useUserFeed(isMyProfile, username);
-  const githubStatisticQueryResult = useGithubStatsQuery(username);
+  const githubStatisticQueryResult = useGithubStatistics(username);
 
   const tabContents = [
     <ProfileFeed key="profile-feed" username={username} {...userFeedProps} />,

--- a/frontend/src/services/hooks/useGithubStatistics.ts
+++ b/frontend/src/services/hooks/useGithubStatistics.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+import { useContext, useEffect } from "react";
+import { UNKNOWN_ERROR_MESSAGE } from "../../constants/messages";
+import SnackBarContext from "../../contexts/SnackbarContext";
+import UserContext from "../../contexts/UserContext";
+import { getAPIErrorMessage, handleHTTPError } from "../../utils/error";
+import { isHttpErrorStatus } from "../../utils/typeGuard";
+import { useGithubStatsQuery } from "../queries";
+
+const useGithubStatistics = (username: string) => {
+  const { data, error, isLoading, isError } = useGithubStatsQuery(username);
+  const { logout } = useContext(UserContext);
+  const { pushSnackbarMessage } = useContext(SnackBarContext);
+
+  const handleError = () => {
+    if (!error) {
+      return;
+    }
+
+    if (axios.isAxiosError(error)) {
+      const { status, data } = error.response ?? {};
+
+      if (status && isHttpErrorStatus(status)) {
+        handleHTTPError(status, {
+          unauthorized: () => logout(),
+        });
+      }
+
+      pushSnackbarMessage(data ? getAPIErrorMessage(data.errorCode) : UNKNOWN_ERROR_MESSAGE);
+    } else {
+      pushSnackbarMessage(UNKNOWN_ERROR_MESSAGE);
+    }
+  };
+
+  useEffect(() => {
+    handleError();
+  }, [error]);
+
+  return { data, isLoading, isError };
+};
+
+export default useGithubStatistics;

--- a/frontend/src/services/queries/githubStats.ts
+++ b/frontend/src/services/queries/githubStats.ts
@@ -2,10 +2,11 @@ import { AxiosError } from "axios";
 import { useQuery } from "react-query";
 import { ErrorResponse, GithubStats } from "../../@types";
 import { QUERY } from "../../constants/queries";
+import { getAccessToken } from "../../storage/storage";
 import { requestGetGithubStats } from "../requests";
 
 export const useGithubStatsQuery = (username: string) => {
-  return useQuery<GithubStats, AxiosError<ErrorResponse>>([QUERY.GET_GITHUB_STATS, username], () =>
-    requestGetGithubStats(username)
+  return useQuery<GithubStats | null, AxiosError<ErrorResponse>>([QUERY.GET_GITHUB_STATS, username], () =>
+    requestGetGithubStats(username, getAccessToken())
   );
 };

--- a/frontend/src/services/requests/githubStats.ts
+++ b/frontend/src/services/requests/githubStats.ts
@@ -2,9 +2,16 @@ import axios from "axios";
 import { GithubStats } from "../../@types";
 import { API_URL } from "../../constants/urls";
 
-export const requestGetGithubStats = async (username: string) => {
-  // const response = await axios.get<GithubStats>(API_URL.GITHUB_STATS(username));
-  const response = await axios.get<GithubStats>(`https://parse-github-stats.herokuapp.com/github-stats/${username}`);
+export const requestGetGithubStats = async (username: string, accessToken: string | null) => {
+  if (!accessToken) {
+    return null;
+  }
+
+  const response = await axios.get<GithubStats>(API_URL.GITHUB_STATS(username), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
   return response.data;
 };


### PR DESCRIPTION
## 상세 내용
- github statistics가 로그인 시에만 보이도록 수정
- github statistics 훅 분리

<br/>

Close #338 
