### PR TITLE
[#339] 팔로잉 및 팔로워 목록 조회 기능

### DIFF
--- a/backend/pick-git/src/docs/asciidoc/profile.adoc
+++ b/backend/pick-git/src/docs/asciidoc/profile.adoc
@@ -55,3 +55,27 @@ include::{snippets}/profiles-contributions-LoggedIn/http-response.adoc[]
 include::{snippets}/profiles-contributions-unLoggedIn/http-request.adoc[]
 ==== Response
 include::{snippets}/profiles-contributions-unLoggedIn/http-response.adoc[]
+
+=== 팔로잉 목록 조회 - 로그인
+==== Request
+include::{snippets}/search-followings-LoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-followings-LoggedIn/http-response.adoc[]
+
+=== 팔로잉 목록 조회 - 비 로그인
+==== Request
+include::{snippets}/search-followings-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-followings-unLoggedIn/http-response.adoc[]
+
+=== 팔로워 목록 조회 - 로그인
+==== Request
+include::{snippets}/search-followers-LoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-followers-LoggedIn/http-response.adoc[]
+
+=== 팔로워 목록 조회 - 비 로그인
+==== Request
+include::{snippets}/search-followers-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-followers-unLoggedIn/http-response.adoc[]

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -64,6 +64,8 @@ public class OAuthConfiguration implements WebMvcConfigurer {
             .addPathPatterns("/api/posts", HttpMethod.GET)
             .addPathPatterns("/api/posts/*", HttpMethod.GET)
             .addPathPatterns("/api/search/**", HttpMethod.GET)
+            .addPathPatterns("/api/profiles/*/followings", HttpMethod.GET)
+            .addPathPatterns("/api/profiles/*/followers", HttpMethod.GET)
             .excludePatterns("/api/profiles/*/followings", HttpMethod.POST, HttpMethod.DELETE)
             .excludePatterns("/api/profiles/me", HttpMethod.GET)
             .excludePatterns("/api/posts/me", HttpMethod.GET);

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -229,6 +229,26 @@ public class UserService {
         return convertToUserSearchResponseDtoWithFollowingAndIncludingMe(loginUser, followings);
     }
 
+    @Transactional(readOnly = true)
+    public List<UserSearchResponseDto> searchFollowers(
+        AuthUserRequestDto authUserRequestDto,
+        FollowSearchRequestDto followSearchRequestDto
+    ) {
+        User target = findUserByName(followSearchRequestDto.getUsername());
+        Pageable pageable = PageRequest.of(
+            Math.toIntExact(followSearchRequestDto.getPage()),
+            Math.toIntExact(followSearchRequestDto.getLimit())
+        );
+        List<User> followers = userRepository.searchFollowersOf(target, pageable);
+
+        if (authUserRequestDto.isGuest()) {
+            return convertToUserSearchResponseDtoWithoutFollowing(followers);
+        }
+
+        User loginUser = findUserByName(authUserRequestDto.getUsername());
+        return convertToUserSearchResponseDtoWithFollowingAndIncludingMe(loginUser, followers);
+    }
+
     private List<UserSearchResponseDto> convertToUserSearchResponseDtoWithFollowingAndIncludingMe(
         User loginUser,
         List<User> followings

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -255,7 +254,7 @@ public class UserService {
     ) {
         return followings.stream()
             .map(followUser -> convert(loginUser, followUser))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     private UserSearchResponseDto convert(User loginUser, User followUser) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/FollowSearchRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/FollowSearchRequestDto.java
@@ -1,0 +1,32 @@
+package com.woowacourse.pickgit.user.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public class FollowSearchRequestDto {
+
+    private String username;
+    private Long page;
+    private Long limit;
+
+    private FollowSearchRequestDto() {
+    }
+
+    public FollowSearchRequestDto(String username, Long page, Long limit) {
+        this.username = username;
+        this.page = page;
+        this.limit = limit;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Long getPage() {
+        return page;
+    }
+
+    public Long getLimit() {
+        return limit;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/UserRepository.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/UserRepository.java
@@ -2,7 +2,6 @@ package com.woowacourse.pickgit.user.domain;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +13,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.basicProfile.name like %:username%")
     List<User> searchByUsernameLike(@Param("username") String username, Pageable pageable);
+
+    @Query("select t from Follow f inner join f.target t on f.source = :user")
+    List<User> searchFollowingsOf(@Param("user") User user, Pageable pageable);
+
+    @Query("select s from Follow f inner join f.source s on f.target = :user")
+    List<User> searchFollowersOf(@Param("user") User user, Pageable pageable);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -180,8 +180,7 @@ public class UserController {
             .build();
         List<UserSearchResponseDto> userSearchResponseDtos =
             userService.searchFollowings(authUserRequestDto, followSearchRequestDto);
-        List<UserSearchResponse> userSearchResponses = convert(userSearchResponseDtos);
-        return ResponseEntity.ok(userSearchResponses);
+        return ResponseEntity.ok(createUserSearchResponses(userSearchResponseDtos));
     }
 
     @GetMapping("/{username}/followers")
@@ -199,17 +198,20 @@ public class UserController {
             .build();
         List<UserSearchResponseDto> userSearchResponseDtos =
             userService.searchFollowers(authUserRequestDto, followSearchRequestDto);
-        List<UserSearchResponse> userSearchResponses = convert(userSearchResponseDtos);
-        return ResponseEntity.ok(userSearchResponses);
+        return ResponseEntity.ok(createUserSearchResponses(userSearchResponseDtos));
     }
 
-    private List<UserSearchResponse> convert(List<UserSearchResponseDto> userSearchResponseDtos) {
+    private List<UserSearchResponse> createUserSearchResponses(
+        List<UserSearchResponseDto> userSearchResponseDtos
+    ) {
         return userSearchResponseDtos.stream()
-            .map(this::convert)
+            .map(this::createUserSearchResponse)
             .collect(toList());
     }
 
-    private UserSearchResponse convert(UserSearchResponseDto userSearchResponseDto) {
+    private UserSearchResponse createUserSearchResponse(
+        UserSearchResponseDto userSearchResponseDto
+    ) {
         return UserSearchResponse.builder()
             .imageUrl(userSearchResponseDto.getImageUrl())
             .username(userSearchResponseDto.getUsername())

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -1,20 +1,26 @@
 package com.woowacourse.pickgit.user.presentation;
 
+import static java.util.stream.Collectors.toList;
+
 import com.woowacourse.pickgit.authentication.domain.Authenticated;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
+import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.presentation.dto.request.ProfileEditRequest;
 import com.woowacourse.pickgit.user.presentation.dto.response.ContributionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.FollowResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.ProfileEditResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.UserProfileResponse;
+import com.woowacourse.pickgit.user.presentation.dto.response.UserSearchResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,6 +29,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -155,6 +162,58 @@ public class UserController {
             .prsCount(responseDto.getPrsCount())
             .issuesCount(responseDto.getIssuesCount())
             .reposCount(responseDto.getReposCount())
+            .build();
+    }
+
+    @GetMapping("/{username}/followings")
+    public ResponseEntity<List<UserSearchResponse>> searchFollowings(
+        @Authenticated AppUser appUser,
+        @PathVariable String username,
+        @RequestParam Long page,
+        @RequestParam Long limit
+    ) {
+        AuthUserRequestDto authUserRequestDto = AuthUserRequestDto.from(appUser);
+        FollowSearchRequestDto followSearchRequestDto = FollowSearchRequestDto.builder()
+            .username(username)
+            .page(page)
+            .limit(limit)
+            .build();
+        List<UserSearchResponseDto> userSearchResponseDtos =
+            userService.searchFollowings(authUserRequestDto, followSearchRequestDto);
+        List<UserSearchResponse> userSearchResponses = convert(userSearchResponseDtos);
+        return ResponseEntity.ok(userSearchResponses);
+    }
+
+    @GetMapping("/{username}/followers")
+    public ResponseEntity<List<UserSearchResponse>> searchFollowers(
+        @Authenticated AppUser appUser,
+        @PathVariable String username,
+        @RequestParam Long page,
+        @RequestParam Long limit
+    ) {
+        AuthUserRequestDto authUserRequestDto = AuthUserRequestDto.from(appUser);
+        FollowSearchRequestDto followSearchRequestDto = FollowSearchRequestDto.builder()
+            .username(username)
+            .page(page)
+            .limit(limit)
+            .build();
+        List<UserSearchResponseDto> userSearchResponseDtos =
+            userService.searchFollowers(authUserRequestDto, followSearchRequestDto);
+        List<UserSearchResponse> userSearchResponses = convert(userSearchResponseDtos);
+        return ResponseEntity.ok(userSearchResponses);
+    }
+
+    private List<UserSearchResponse> convert(List<UserSearchResponseDto> userSearchResponseDtos) {
+        return userSearchResponseDtos.stream()
+            .map(this::convert)
+            .collect(toList());
+    }
+
+    private UserSearchResponse convert(UserSearchResponseDto userSearchResponseDto) {
+        return UserSearchResponse.builder()
+            .imageUrl(userSearchResponseDto.getImageUrl())
+            .username(userSearchResponseDto.getUsername())
+            .following(userSearchResponseDto.getFollowing())
             .build();
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/UserSearchResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/UserSearchResponse.java
@@ -1,0 +1,32 @@
+package com.woowacourse.pickgit.user.presentation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class UserSearchResponse {
+
+    private String imageUrl;
+    private String username;
+    private Boolean following;
+
+    private UserSearchResponse() {
+    }
+
+    public UserSearchResponse(String imageUrl, String username, Boolean following) {
+        this.imageUrl = imageUrl;
+        this.username = username;
+        this.following = following;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Boolean getFollowing() {
+        return following;
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/Acceptance_GetFollowingsAndFollowers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/Acceptance_GetFollowingsAndFollowers.java
@@ -1,0 +1,204 @@
+package com.woowacourse.pickgit.acceptance.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.common.request_builder.PickGitRequest;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
+import com.woowacourse.pickgit.user.application.UserService;
+import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
+import com.woowacourse.pickgit.user.domain.User;
+import com.woowacourse.pickgit.user.domain.UserRepository;
+import com.woowacourse.pickgit.user.presentation.dto.response.UserSearchResponse;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(InfrastructureTestConfiguration.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+class Acceptance_GetFollowingsAndFollowers {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("로그인 - 특정 유저의 팔로잉 목록을 조회한다. (팔로잉 여부 true/false, 본인은 null)")
+    @Test
+    void searchFollowings_Login_FollowingVarious() {
+        // given
+        User target = UserFactory.user("target");
+        List<User> usersInDb = new ArrayList<>(UserFactory.mockSearchUsers());
+        usersInDb.add(UserFactory.user("testUser"));
+        userRepository.save(target);
+        userRepository.saveAll(usersInDb);
+
+        AuthUserRequestDto targetAuthDto =
+            AuthUserRequestDto.from(new LoginUser(target.getName(), "token"));
+        for (User user : usersInDb) {
+            userService.followUser(targetAuthDto, user.getName());
+        }
+        AuthUserRequestDto testerAuthDto =
+            AuthUserRequestDto.from(new LoginUser("testUser", "token"));
+        for (int i = 0; i < 3; i++) {
+            userService.followUser(testerAuthDto, usersInDb.get(i).getName());
+        }
+
+        // when
+        List<UserSearchResponse> response = PickGitRequest.get(
+            String.format("/api/profiles/%s/followings?page=%s&limit=%s", "target", "0", "10")
+        ).withUser()
+            .extract()
+            .as(new TypeRef<List<UserSearchResponse>>() {
+            });
+
+        // then
+        assertThat(response)
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), true),
+                tuple(usersInDb.get(1).getName(), true),
+                tuple(usersInDb.get(2).getName(), true),
+                tuple(usersInDb.get(3).getName(), false),
+                tuple(usersInDb.get(4).getName(), false),
+                tuple(usersInDb.get(5).getName(), null)
+            ).hasSize(6);
+    }
+
+    @DisplayName("비로그인 - 특정 유저의 팔로잉 목록을 조회한다. (팔로잉 여부 모두 null)")
+    @Test
+    void searchFollowings_Guest_FollowingNull() {
+        // given
+        User target = UserFactory.user("target");
+        List<User> usersInDb = UserFactory.mockSearchUsers();
+        userRepository.save(target);
+        userRepository.saveAll(usersInDb);
+
+        AuthUserRequestDto targetAuthDto =
+            AuthUserRequestDto.from(new LoginUser(target.getName(), "token"));
+        for (User user : usersInDb) {
+            userService.followUser(targetAuthDto, user.getName());
+        }
+
+        // when
+        List<UserSearchResponse> response = PickGitRequest.get(
+            String.format("/api/profiles/%s/followings?page=%s&limit=%s", "target", "0", "10")
+        ).withGuest()
+            .extract()
+            .as(new TypeRef<List<UserSearchResponse>>() {
+            });
+
+        // then
+        assertThat(response)
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), null),
+                tuple(usersInDb.get(1).getName(), null),
+                tuple(usersInDb.get(2).getName(), null),
+                tuple(usersInDb.get(3).getName(), null),
+                tuple(usersInDb.get(4).getName(), null)
+            ).hasSize(5);
+    }
+
+    @DisplayName("로그인 - 특정 유저의 팔로워 목록을 조회한다. (팔로잉 여부 true/false, 본인은 null)")
+    @Test
+    void searchFollowers_Login_FollowingVarious() {
+        // given
+        User target = UserFactory.user("target");
+        List<User> usersInDb = new ArrayList<>(UserFactory.mockSearchUsers());
+        usersInDb.add(UserFactory.user("testUser"));
+        userRepository.save(target);
+        userRepository.saveAll(usersInDb);
+
+        for (User user : usersInDb) {
+            AuthUserRequestDto mockUserAuthDto =
+                AuthUserRequestDto.from(new LoginUser(user.getName(), "token"));
+            userService.followUser(mockUserAuthDto, target.getName());
+        }
+        AuthUserRequestDto testerAuthDto =
+            AuthUserRequestDto.from(new LoginUser("testUser", "token"));
+        for (int i = 0; i < 3; i++) {
+            userService.followUser(testerAuthDto, usersInDb.get(i).getName());
+        }
+
+        // when
+        List<UserSearchResponse> response = PickGitRequest.get(
+            String.format("/api/profiles/%s/followers?page=%s&limit=%s", "target", "0", "10")
+        ).withUser()
+            .extract()
+            .as(new TypeRef<List<UserSearchResponse>>() {
+            });
+
+        // then
+        assertThat(response)
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), true),
+                tuple(usersInDb.get(1).getName(), true),
+                tuple(usersInDb.get(2).getName(), true),
+                tuple(usersInDb.get(3).getName(), false),
+                tuple(usersInDb.get(4).getName(), false),
+                tuple(usersInDb.get(5).getName(), null)
+            ).hasSize(6);
+    }
+
+    @DisplayName("비로그인 - 특정 유저의 팔로워 목록을 조회한다. (팔로잉 여부 모두 null)")
+    @Test
+    void searchFollowers_Guest_FollowingNull() {
+        // given
+        User target = UserFactory.user("target");
+        List<User> usersInDb = UserFactory.mockSearchUsers();
+        userRepository.save(target);
+        userRepository.saveAll(usersInDb);
+
+        for (User user : usersInDb) {
+            AuthUserRequestDto mockUserAuthDto =
+                AuthUserRequestDto.from(new LoginUser(user.getName(), "token"));
+            userService.followUser(mockUserAuthDto, target.getName());
+        }
+
+        // when
+        List<UserSearchResponse> response = PickGitRequest.get(
+            String.format("/api/profiles/%s/followers?page=%s&limit=%s", "target", "0", "10")
+        ).withGuest()
+            .extract()
+            .as(new TypeRef<List<UserSearchResponse>>() {
+            });
+
+        // then
+        assertThat(response)
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), null),
+                tuple(usersInDb.get(1).getName(), null),
+                tuple(usersInDb.get(2).getName(), null),
+                tuple(usersInDb.get(3).getName(), null),
+                tuple(usersInDb.get(4).getName(), null)
+            ).hasSize(5);
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
@@ -34,6 +34,11 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class UserAcceptance_GetFollowingsAndFollowers {
 
+    private static final String FOLLOWINGS_API_URL =
+        "/api/profiles/{username}/followings?page={page}&limit={limit}";
+    private static final String FOLLOWERS_API_URL =
+        "/api/profiles/{username}/followers?page={page}&limit={limit}";
+
     @LocalServerPort
     private int port;
 
@@ -70,11 +75,11 @@ class UserAcceptance_GetFollowingsAndFollowers {
         }
 
         // when
-        List<UserSearchResponse> response = PickGitRequest.get(
-            String.format("/api/profiles/%s/followings?page=%s&limit=%s", "target", "0", "10")
-        ).withUser()
+        List<UserSearchResponse> response = PickGitRequest
+            .get(FOLLOWINGS_API_URL, "target", "0", "10")
+            .withUser()
             .extract()
-            .as(new TypeRef<List<UserSearchResponse>>() {
+            .as(new TypeRef<>() {
             });
 
         // then
@@ -106,11 +111,12 @@ class UserAcceptance_GetFollowingsAndFollowers {
         }
 
         // when
-        List<UserSearchResponse> response = PickGitRequest.get(
-            String.format("/api/profiles/%s/followings?page=%s&limit=%s", "target", "0", "10")
-        ).withGuest()
+        List<UserSearchResponse> response = PickGitRequest
+            .get(FOLLOWINGS_API_URL, "target", "0",
+                "10")
+            .withGuest()
             .extract()
-            .as(new TypeRef<List<UserSearchResponse>>() {
+            .as(new TypeRef<>() {
             });
 
         // then
@@ -147,11 +153,11 @@ class UserAcceptance_GetFollowingsAndFollowers {
         }
 
         // when
-        List<UserSearchResponse> response = PickGitRequest.get(
-            String.format("/api/profiles/%s/followers?page=%s&limit=%s", "target", "0", "10")
-        ).withUser()
+        List<UserSearchResponse> response = PickGitRequest
+            .get(FOLLOWERS_API_URL, "target", "0", "10")
+            .withUser()
             .extract()
-            .as(new TypeRef<List<UserSearchResponse>>() {
+            .as(new TypeRef<>() {
             });
 
         // then
@@ -183,11 +189,11 @@ class UserAcceptance_GetFollowingsAndFollowers {
         }
 
         // when
-        List<UserSearchResponse> response = PickGitRequest.get(
-            String.format("/api/profiles/%s/followers?page=%s&limit=%s", "target", "0", "10")
-        ).withGuest()
+        List<UserSearchResponse> response = PickGitRequest
+            .get(FOLLOWERS_API_URL, "target", "0", "10")
+            .withGuest()
             .extract()
-            .as(new TypeRef<List<UserSearchResponse>>() {
+            .as(new TypeRef<>() {
             });
 
         // then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
-class Acceptance_GetFollowingsAndFollowers {
+class UserAcceptance_GetFollowingsAndFollowers {
 
     @LocalServerPort
     private int port;

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -519,12 +519,14 @@ class UserServiceIntegrationTest {
 
         // then
         assertThat(response)
-            .extracting("username")
-            .containsExactly(usersInDb.stream().map(User::getName).toArray());
-
-        assertThat(response)
-            .extracting("following")
-            .containsExactly(true, true, true, false, null);
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), true),
+                tuple(usersInDb.get(1).getName(), true),
+                tuple(usersInDb.get(2).getName(), true),
+                tuple(usersInDb.get(3).getName(), false),
+                tuple(usersInDb.get(4).getName(), null)
+            );
     }
 
     @DisplayName("비로그인 - 특정 유저의 팔로잉 목록을 조회한다. (팔로잉 필드는 모두 null)")
@@ -555,12 +557,14 @@ class UserServiceIntegrationTest {
 
         // then
         assertThat(response)
-            .extracting("username")
-            .containsExactly(usersInDb.stream().map(User::getName).toArray());
-
-        assertThat(response)
-            .extracting("following")
-            .containsOnlyNulls();
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), null),
+                tuple(usersInDb.get(1).getName(), null),
+                tuple(usersInDb.get(2).getName(), null),
+                tuple(usersInDb.get(3).getName(), null),
+                tuple(usersInDb.get(4).getName(), null)
+            );
     }
 
     @DisplayName("로그인 - 특정 유저의 팔로워 목록을 조회한다. (팔로잉 필드는 true/false, 본인은 null)")
@@ -594,12 +598,14 @@ class UserServiceIntegrationTest {
 
         // then
         assertThat(response)
-            .extracting("username")
-            .containsExactly(usersInDb.stream().map(User::getName).toArray());
-
-        assertThat(response)
-            .extracting("following")
-            .containsExactly(true, true, true, false, null);
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), true),
+                tuple(usersInDb.get(1).getName(), true),
+                tuple(usersInDb.get(2).getName(), true),
+                tuple(usersInDb.get(3).getName(), false),
+                tuple(usersInDb.get(4).getName(), null)
+            );
     }
 
     @DisplayName("비로그인 - 특정 유저의 팔로워 목록을 조회한다. (팔로잉 필드는 모두 null)")
@@ -630,12 +636,14 @@ class UserServiceIntegrationTest {
 
         // then
         assertThat(response)
-            .extracting("username")
-            .containsExactly(usersInDb.stream().map(User::getName).toArray());
-
-        assertThat(response)
-            .extracting("following")
-            .containsOnlyNulls();
+            .extracting("username", "following")
+            .containsExactly(
+                tuple(usersInDb.get(0).getName(), null),
+                tuple(usersInDb.get(1).getName(), null),
+                tuple(usersInDb.get(2).getName(), null),
+                tuple(usersInDb.get(3).getName(), null),
+                tuple(usersInDb.get(4).getName(), null)
+            );
     }
 
     private AuthUserRequestDto createLoginAuthUserRequestDto(String username) {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.pickgit.unit.user.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -822,12 +823,11 @@ class UserServiceTest {
 
                 // then
                 assertThat(response)
-                    .extracting("username")
-                    .containsExactly("ala", "hello");
-
-                assertThat(response)
-                    .extracting("following")
-                    .containsOnlyNulls();
+                    .extracting("username", "following")
+                    .containsExactly(
+                        tuple("ala", null),
+                        tuple("hello", null)
+                    );
 
                 verify(userRepository, times(1)).findByBasicProfile_Name("target");
                 verify(userRepository, times(1))
@@ -896,12 +896,12 @@ class UserServiceTest {
 
                 // then
                 assertThat(response)
-                    .extracting("username")
-                    .containsExactly("ala", "hello", "source");
-
-                assertThat(response)
-                    .extracting("following")
-                    .containsExactly(true, false, null);
+                    .extracting("username", "following")
+                    .containsExactly(
+                        tuple("ala", true),
+                        tuple("hello", false),
+                        tuple("source", null)
+                    );
 
                 verify(userRepository, times(1)).findByBasicProfile_Name("target");
                 verify(userRepository, times(1))
@@ -971,12 +971,11 @@ class UserServiceTest {
 
                 // then
                 assertThat(response)
-                    .extracting("username")
-                    .containsExactly("ala", "hello");
-
-                assertThat(response)
-                    .extracting("following")
-                    .containsOnlyNulls();
+                    .extracting("username", "following")
+                    .containsExactly(
+                        tuple("ala", null),
+                        tuple("hello", null)
+                    );
 
                 verify(userRepository, times(1)).findByBasicProfile_Name("target");
                 verify(userRepository, times(1))
@@ -1045,12 +1044,12 @@ class UserServiceTest {
 
                 // then
                 assertThat(response)
-                    .extracting("username")
-                    .containsExactly("ala", "hello", "source");
-
-                assertThat(response)
-                    .extracting("following")
-                    .containsExactly(true, false, null);
+                    .extracting("username", "following")
+                    .containsExactly(
+                        tuple("ala", true),
+                        tuple("hello", false),
+                        tuple("source", null)
+                    );
 
                 verify(userRepository, times(1)).findByBasicProfile_Name("target");
                 verify(userRepository, times(1))

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import com.woowacourse.pickgit.exception.user.SameSourceTargetUserException;
 import com.woowacourse.pickgit.post.domain.repository.PickGitStorage;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
@@ -687,11 +689,6 @@ class UserServiceTest {
         verify(userRepository, times(1)).findByBasicProfile_Name(loginUser.getName());
     }
 
-    private AuthUserRequestDto createLoginAuthUserRequestDto(String username) {
-        AppUser appUser = new LoginUser(username, "Bearer testToken");
-        return AuthUserRequestDto.from(appUser);
-    }
-
     @DisplayName("비 로그인 - 저장된 유저중 유사한 이름을 가진 유저를 검색한다. (팔로잉 필드 null)")
     @Test
     void searchUser_GuestUser_Success() {
@@ -727,10 +724,6 @@ class UserServiceTest {
         verify(userRepository, times(1))
             .searchByUsernameLike(searchKeyword, PageRequest.of(page, limit));
         verify(userRepository, times(0)).findByBasicProfile_Name(anyString());
-    }
-
-    private AuthUserRequestDto createGuestAuthUserRequestDto() {
-        return AuthUserRequestDto.from(new GuestUser());
     }
 
     @DisplayName("calculateContributions 메소드는")
@@ -791,5 +784,163 @@ class UserServiceTest {
                     .findByBasicProfile_Name("testUser");
             }
         }
+    }
+
+    @DisplayName("searchFollowings 메서드는")
+    @Nested
+    class Describe_searchFollowings {
+
+        @DisplayName("게스트일 때")
+        @Nested
+        class Context_Guest {
+
+            @DisplayName("특정 유저가 팔로잉 중인 유저 목록을 조회할 수 있다. - 팔로우 여부 null")
+            @Test
+            void searchFollowings_Guest_FollowingNull() {
+                // given
+                AuthUserRequestDto authUserRequestDto = createGuestAuthUserRequestDto();
+                FollowSearchRequestDto followSearchRequestDto =
+                    FollowSearchRequestDto.builder()
+                        .username("target")
+                        .page(0L)
+                        .limit(3L)
+                        .build();
+                User target = UserFactory.user(1L, "target");
+                List<User> followings = List.of(
+                    UserFactory.user(2L, "ala"),
+                    UserFactory.user(3L, "hello")
+                );
+
+                given(userRepository.findByBasicProfile_Name("target"))
+                    .willReturn(Optional.of(target));
+                given(userRepository.searchFollowingsOf(eq(target), eq(PageRequest.of(0, 3))))
+                    .willReturn(followings);
+
+                // when
+                List<UserSearchResponseDto> response =
+                    userService.searchFollowings(authUserRequestDto, followSearchRequestDto);
+
+                // then
+                assertThat(response)
+                    .extracting("username")
+                    .containsExactly("ala", "hello");
+
+                assertThat(response)
+                    .extracting("following")
+                    .containsOnlyNulls();
+
+                verify(userRepository, times(1)).findByBasicProfile_Name("target");
+                verify(userRepository, times(1))
+                    .searchFollowingsOf(eq(target), eq(PageRequest.of(0, 3)));
+            }
+
+            @DisplayName("존재하지 않는 유저의 팔로잉 목록을 조회할 수 없다.")
+            @Test
+            void searchFollowings_TargetNotExists_ExceptionThrown() {
+                // given
+                AuthUserRequestDto authUserRequestDto = createGuestAuthUserRequestDto();
+                FollowSearchRequestDto followSearchRequestDto =
+                    FollowSearchRequestDto.builder()
+                        .username("target")
+                        .page(0L)
+                        .limit(3L)
+                        .build();
+
+                given(userRepository.findByBasicProfile_Name("target"))
+                    .willReturn(Optional.empty());
+
+                // when, then
+                assertThatCode(() ->
+                    userService.searchFollowings(authUserRequestDto, followSearchRequestDto)
+                ).isInstanceOf(InvalidUserException.class);
+
+                // then
+                verify(userRepository, times(1)).findByBasicProfile_Name("target");
+            }
+        }
+
+        @DisplayName("로그인 유저일 때")
+        @Nested
+        class Context_LoginUser {
+
+            @DisplayName("특정 유저가 팔로잉 중인 유저 목록을 조회할 수 있다. - 팔로우 여부 true/false, 본인은 null")
+            @Test
+            void searchFollowings_LoginUser_FollowingNull() {
+                // given
+                AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("source");
+                FollowSearchRequestDto followSearchRequestDto =
+                    FollowSearchRequestDto.builder()
+                        .username("target")
+                        .page(0L)
+                        .limit(3L)
+                        .build();
+                User loginUser = UserFactory.user(4L, "source");
+                User target = UserFactory.user(1L, "target");
+                List<User> followings = List.of(
+                    UserFactory.user(2L, "ala"),
+                    UserFactory.user(3L, "hello"),
+                    loginUser
+                );
+                loginUser.follow(followings.get(0));
+
+                given(userRepository.findByBasicProfile_Name("target"))
+                    .willReturn(Optional.of(target));
+                given(userRepository.searchFollowingsOf(eq(target), eq(PageRequest.of(0, 3))))
+                    .willReturn(followings);
+                given(userRepository.findByBasicProfile_Name("source"))
+                    .willReturn(Optional.of(loginUser));
+
+                // when
+                List<UserSearchResponseDto> response =
+                    userService.searchFollowings(authUserRequestDto, followSearchRequestDto);
+
+                // then
+                assertThat(response)
+                    .extracting("username")
+                    .containsExactly("ala", "hello", "source");
+
+                assertThat(response)
+                    .extracting("following")
+                    .containsExactly(true, false, null);
+
+                verify(userRepository, times(1)).findByBasicProfile_Name("target");
+                verify(userRepository, times(1))
+                    .searchFollowingsOf(eq(target), eq(PageRequest.of(0, 3)));
+                verify(userRepository, times(1)).findByBasicProfile_Name("source");
+            }
+
+            @DisplayName("존재하지 않는 유저의 팔로잉 목록을 조회할 수 없다.")
+            @Test
+            void searchFollowings_TargetNotExists_ExceptionThrown() {
+                // given
+                AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("source");
+                FollowSearchRequestDto followSearchRequestDto =
+                    FollowSearchRequestDto.builder()
+                        .username("target")
+                        .page(0L)
+                        .limit(3L)
+                        .build();
+
+                given(userRepository.findByBasicProfile_Name("target"))
+                    .willReturn(Optional.empty());
+
+                // when, then
+                assertThatCode(() ->
+                    userService.searchFollowings(authUserRequestDto, followSearchRequestDto)
+                ).isInstanceOf(InvalidUserException.class);
+
+                // then
+                verify(userRepository, times(1)).findByBasicProfile_Name("target");
+            }
+        }
+    }
+
+    private AuthUserRequestDto createLoginAuthUserRequestDto(String username) {
+        AppUser appUser = new LoginUser(username, "Bearer testToken");
+        return AuthUserRequestDto.from(appUser);
+    }
+
+    private AuthUserRequestDto createGuestAuthUserRequestDto() {
+        return AuthUserRequestDto.from(new GuestUser());
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/domain/UserRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/domain/UserRepositoryTest.java
@@ -318,4 +318,138 @@ class UserRepositoryTest {
             }
         }
     }
+
+    @DisplayName("searchFollowingsOf 메서드는")
+    @Nested
+    class Describe_searchFollowingsOf {
+
+        @DisplayName("특정 유저가 팔로잉하는 유저가 없다면")
+        @Nested
+        class Context_NoFollowingsAvailable {
+
+            @DisplayName("빈 리스트를 반환한다.")
+            @Test
+            void searchFollowingsOf_NoFollowings_EmptyList() {
+                // given
+                User user1 = UserFactory.user("user1");
+                Pageable pageable = PageRequest.of(0, 2);
+
+                userRepository.save(user1);
+
+                testEntityManager.flush();
+                testEntityManager.clear();
+
+                // when
+                List<User> followings = userRepository.searchFollowingsOf(user1, pageable);
+
+                // then
+                assertThat(followings).isEmpty();
+            }
+        }
+
+        @DisplayName("특정 유저가 팔로잉하는 유저가 있다면")
+        @Nested
+        class Context_FollowingsAvailable {
+
+            @DisplayName("페이징 조건에 맞춰 팔로잉중인 유저 리스트를 반환한다.")
+            @Test
+            void searchFollowingsOf_FollowingsAvailable_Pageable() {
+                // given
+                User user1 = UserFactory.user("user1");
+                User user2 = UserFactory.user("user2");
+                User user3 = UserFactory.user("user3");
+                User user4 = UserFactory.user("user4");
+                Pageable pageable = PageRequest.of(0, 2);
+
+                userRepository.save(user1);
+                userRepository.save(user2);
+                userRepository.save(user3);
+                userRepository.save(user4);
+
+                user1.follow(user2);
+                user1.follow(user3);
+                user1.follow(user4);
+
+                testEntityManager.flush();
+                testEntityManager.clear();
+
+                // when
+                List<User> followings = userRepository.searchFollowingsOf(user1, pageable);
+
+                // then
+                assertThat(followings)
+                    .extracting("basicProfile")
+                    .extracting("name")
+                    .containsExactly("user2", "user3")
+                    .hasSize(2);
+            }
+        }
+    }
+
+    @DisplayName("searchFollowersOf 메서드는")
+    @Nested
+    class Describe_searchFollowersOf {
+
+        @DisplayName("특정 유저를 팔로우하는 팔로워 유저가 없다면")
+        @Nested
+        class Context_NoFollowersAvailable {
+
+            @DisplayName("빈 리스트를 반환한다.")
+            @Test
+            void searchFollowersOf_NoFollowers_EmptyList() {
+                // given
+                User user1 = UserFactory.user("user1");
+                Pageable pageable = PageRequest.of(0, 2);
+
+                userRepository.save(user1);
+
+                testEntityManager.flush();
+                testEntityManager.clear();
+
+                // when
+                List<User> followers = userRepository.searchFollowersOf(user1, pageable);
+
+                // then
+                assertThat(followers).isEmpty();
+            }
+        }
+
+        @DisplayName("특정 유저를 팔로우하는 팔로워 유저가 있다면")
+        @Nested
+        class Context_FollowersAvailable {
+
+            @DisplayName("페이징 조건에 맞춰 팔로워 유저 리스트를 반환한다.")
+            @Test
+            void searchFollowersOf_FollowersAvailable_Pageable() {
+                // given
+                User user1 = UserFactory.user("user1");
+                User user2 = UserFactory.user("user2");
+                User user3 = UserFactory.user("user3");
+                User user4 = UserFactory.user("user4");
+                Pageable pageable = PageRequest.of(0, 2);
+
+                userRepository.save(user1);
+                userRepository.save(user2);
+                userRepository.save(user3);
+                userRepository.save(user4);
+
+                user1.follow(user4);
+                user2.follow(user4);
+                user3.follow(user4);
+
+                testEntityManager.flush();
+                testEntityManager.clear();
+
+                // when
+                List<User> followers = userRepository.searchFollowersOf(user4, pageable);
+
+                // then
+                assertThat(followers)
+                    .extracting("basicProfile")
+                    .extracting("name")
+                    .containsExactly("user1", "user2")
+                    .hasSize(2);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 상세 내용

* 특정 유저의 팔로잉 목록과 팔로워 목록 조회
* 인수 테스트, 통합 테스트, 슬라이싱 테스트 작성

<br/>

## 기타

* 이번에 구현한 기능들 + 추후 좋아요한 유저 목록 조회 기능들이 유저 검색과 비슷한 양상의 요청 및 응답을 받고 있습니다.
* 실제로 이전에 마크가 구현해둔 메서드를 재활용했는데요. 
  * 검색할 때는 자기자신이 포함되는 결과는 제거했는데, 팔로잉이나 팔로워 목록 조회 때는 자기 자신이 포함된 결과는 반환해야해서 완벽하게 재활용하지는 못했습니다.
* 따라서 UserController의 팔로잉/팔로워 목록 조회 메서드를 UserSearchController로 옮기는건 어떻게 생각하시나요?
  * 엄밀하게 말하면 검색 기능은 아닌데... 관련 유저들을 검색하는 기능인것같기도하고... 아무튼 UserController에 위치시켰는데 고민되네요.

<br/>

Close #339
