### PR TITLE
[#340] 프로필 이미지 수정/정보 수정 API 기능 분리

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -54,6 +54,7 @@ public class OAuthConfiguration implements WebMvcConfigurer {
             .addPathPatterns("/api/posts/*/likes", HttpMethod.PUT, HttpMethod.DELETE)
             .addPathPatterns("/api/posts/*/comments", HttpMethod.POST)
             .addPathPatterns("/api/profiles/me", HttpMethod.GET, HttpMethod.POST)
+            .addPathPatterns("/api/profiles/me/*", HttpMethod.PUT)
             .addPathPatterns("/api/profiles/*/followings", HttpMethod.POST, HttpMethod.DELETE)
             .addPathPatterns("/api/posts/*", HttpMethod.PUT, HttpMethod.DELETE)
             .addPathPatterns("/api/profiles/*/contributions", HttpMethod.GET);

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PickGitStorage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PickGitStorage.java
@@ -9,5 +9,6 @@ public interface PickGitStorage {
 
     List<String> store(List<File> files, String userName);
     Optional<String> store(File file, String userName);
+    File fileFrom(byte[] image);
     List<String> storeMultipartFile(List<MultipartFile> multipartFiles, String userName);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PickGitStorage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PickGitStorage.java
@@ -8,7 +8,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface PickGitStorage {
 
     List<String> store(List<File> files, String userName);
-    Optional<String> store(File file, String userName);
-    File fileFrom(byte[] image);
     List<String> storeMultipartFile(List<MultipartFile> multipartFiles, String userName);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
@@ -46,16 +46,6 @@ public class S3Storage implements PickGitStorage {
         return response.getUrls();
     }
 
-    @Override
-    public Optional<String> store(File file, String userName) {
-        List<String> imageUrls = restClient
-            .postForEntity(s3ProxyUrl, createBody(List.of(file), userName), StorageDto.class)
-            .getBody()
-            .getUrls();
-
-        return Optional.ofNullable(imageUrls.get(0));
-    }
-
     private MultiValueMap<String, Object> createBody(
         List<File> files,
         String userName
@@ -101,20 +91,6 @@ public class S3Storage implements PickGitStorage {
 
             return tempFile.toFile();
         } catch (IOException ioException) {
-            throw new PlatformHttpErrorException();
-        }
-    }
-
-    @Override
-    public File fileFrom(byte[] image) {
-        try {
-            Path path = Files.write(
-                Files.createTempFile(null, null),
-                image
-            );
-
-            return path.toFile();
-        } catch (IOException e) {
             throw new PlatformHttpErrorException();
         }
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/S3Storage.java
@@ -105,6 +105,20 @@ public class S3Storage implements PickGitStorage {
         }
     }
 
+    @Override
+    public File fileFrom(byte[] image) {
+        try {
+            Path path = Files.write(
+                Files.createTempFile(null, null),
+                image
+            );
+
+            return path.toFile();
+        } catch (IOException e) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+
     public static class StorageDto {
 
         private List<String> urls;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -158,23 +158,10 @@ public class UserService {
     }
 
     private String saveImageAndGetUrl(byte[] imageSource, String username) {
-        File imgFile = fileFrom(imageSource);
+        File imgFile = pickGitStorage.fileFrom(imageSource);
         return pickGitStorage
             .store(imgFile, username)
             .orElseThrow(PlatformHttpErrorException::new);
-    }
-
-    private File fileFrom(byte[] image) {
-        try {
-            Path path = Files.write(
-                Files.createTempFile(null, null),
-                image
-            );
-
-            return path.toFile();
-        } catch (IOException e) {
-            throw new PlatformHttpErrorException();
-        }
     }
 
     public String editProfileDescription(

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/UserService.java
@@ -9,10 +9,12 @@ import com.woowacourse.pickgit.post.domain.repository.PickGitStorage;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileImageEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileImageEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.domain.Contribution;
@@ -139,6 +141,50 @@ public class UserService {
         return pickGitStorage
             .store(file, username)
             .orElseThrow(PlatformHttpErrorException::new);
+    }
+
+    public ProfileImageEditResponseDto editProfileImage(
+        AuthUserRequestDto authUserRequestDto,
+        ProfileImageEditRequestDto profileImageEditRequestDto
+    ) {
+        User user = findUserByName(authUserRequestDto.getUsername());
+
+        String userImageUrl = saveImageAndGetUrl(
+            profileImageEditRequestDto.getImage(),
+            user.getName()
+        );
+        user.updateProfileImage(userImageUrl);
+        return new ProfileImageEditResponseDto(userImageUrl);
+    }
+
+    private String saveImageAndGetUrl(byte[] imageSource, String username) {
+        File imgFile = fileFrom(imageSource);
+        return pickGitStorage
+            .store(imgFile, username)
+            .orElseThrow(PlatformHttpErrorException::new);
+    }
+
+    private File fileFrom(byte[] image) {
+        try {
+            Path path = Files.write(
+                Files.createTempFile(null, null),
+                image
+            );
+
+            return path.toFile();
+        } catch (IOException e) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+
+    public String editProfileDescription(
+        AuthUserRequestDto authUserRequestDto,
+        String description
+    ) {
+        User user = findUserByName(authUserRequestDto.getUsername());
+
+        user.updateDescription(description);
+        return description;
     }
 
     public FollowResponseDto followUser(AuthUserRequestDto requestDto, String targetName) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/ProfileImageEditRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/ProfileImageEditRequestDto.java
@@ -1,0 +1,18 @@
+package com.woowacourse.pickgit.user.application.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImageEditRequestDto {
+
+    private byte[] image;
+
+    private ProfileImageEditRequestDto() {
+    }
+
+    public ProfileImageEditRequestDto(byte[] image) {
+        this.image = image;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/response/ProfileImageEditResponseDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/response/ProfileImageEditResponseDto.java
@@ -1,0 +1,18 @@
+package com.woowacourse.pickgit.user.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImageEditResponseDto {
+
+    private String imageUrl;
+
+    private ProfileImageEditResponseDto() {
+    }
+
+    public ProfileImageEditResponseDto(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/PickGitProfileStorage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/profile/PickGitProfileStorage.java
@@ -1,0 +1,10 @@
+package com.woowacourse.pickgit.user.domain.profile;
+
+import java.io.File;
+import java.util.Optional;
+
+public interface PickGitProfileStorage {
+
+    Optional<String> store(File file, String userName);
+    String storeByteFile(byte[] file, String userName);
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/S3PickGitProfileStorage.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/S3PickGitProfileStorage.java
@@ -1,0 +1,86 @@
+package com.woowacourse.pickgit.user.infrastructure;
+
+import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
+import com.woowacourse.pickgit.post.domain.util.RestClient;
+import com.woowacourse.pickgit.post.infrastructure.S3Storage.StorageDto;
+import com.woowacourse.pickgit.user.domain.profile.PickGitProfileStorage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Component
+@Profile("!test")
+public class S3PickGitProfileStorage implements PickGitProfileStorage {
+
+    private static final String MULTIPART_KEY = "files";
+
+    private final RestClient restClient;
+    private final String s3ProxyUrl;
+
+    public S3PickGitProfileStorage(
+        RestClient restClient,
+        @Value("${storage.pickgit.s3proxy}") String s3ProxyUrl
+    ) {
+        this.restClient = restClient;
+        this.s3ProxyUrl = s3ProxyUrl;
+    }
+
+    @Override
+    public Optional<String> store(File file, String userName) {
+        List<String> imageUrls = restClient
+            .postForEntity(s3ProxyUrl, createBody(List.of(file), userName), StorageDto.class)
+            .getBody()
+            .getUrls();
+
+        return Optional.ofNullable(imageUrls.get(0));
+    }
+
+    private MultiValueMap<String, Object> createBody(
+        List<File> files,
+        String userName
+    ) {
+        MultiValueMap<String, Object> body = createMultipartMap(files);
+        body.add("userName", userName);
+        return body;
+    }
+
+    private MultiValueMap<String, Object> createMultipartMap(List<File> files) {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+        files.forEach(file -> body.add(MULTIPART_KEY, new FileSystemResource(file)));
+
+        return body;
+    }
+
+    public String storeByteFile(byte[] byteFile, String userName) {
+        return saveImageAndGetUrl(byteFile, userName);
+    }
+
+    private String saveImageAndGetUrl(byte[] imageSource, String username) {
+        File imgFile = fileFrom(imageSource);
+        return store(imgFile, username)
+            .orElseThrow(PlatformHttpErrorException::new);
+    }
+
+    private File fileFrom(byte[] image) {
+        try {
+            Path path = Files.write(
+                Files.createTempFile(null, null),
+                image
+            );
+
+            return path.toFile();
+        } catch (IOException e) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -8,19 +8,25 @@ import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileImageEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileImageEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
-import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
+import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
+import com.woowacourse.pickgit.user.presentation.dto.request.ProfileDescriptionRequest;
 import com.woowacourse.pickgit.user.presentation.dto.request.ProfileEditRequest;
 import com.woowacourse.pickgit.user.presentation.dto.response.ContributionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.FollowResponse;
+import com.woowacourse.pickgit.user.presentation.dto.response.ProfileDescriptionResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.ProfileEditResponse;
+import com.woowacourse.pickgit.user.presentation.dto.response.ProfileImageEditResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.UserProfileResponse;
 import com.woowacourse.pickgit.user.presentation.dto.response.UserSearchResponse;
 import java.util.List;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,6 +34,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -135,6 +143,34 @@ public class UserController {
                 responseDto.getDescription()
             )
         );
+    }
+
+    @PutMapping("/me/image")
+    public ResponseEntity<ProfileImageEditResponse> editProfileImage(
+        @Authenticated AppUser appUser,
+        @RequestBody byte[] image
+    ) {
+        AuthUserRequestDto authUserRequestDto = AuthUserRequestDto.from(appUser);
+        ProfileImageEditRequestDto profileImageEditRequestDto = ProfileImageEditRequestDto
+            .builder()
+            .image(image)
+            .build();
+        ProfileImageEditResponseDto responseDto =
+            userService.editProfileImage(authUserRequestDto, profileImageEditRequestDto);
+        return ResponseEntity.ok(new ProfileImageEditResponse(responseDto.getImageUrl()));
+    }
+
+    @PutMapping("/me/description")
+    public ResponseEntity<ProfileDescriptionResponse> editProfileDescription(
+        @Authenticated AppUser appUser,
+        @Valid @RequestBody ProfileDescriptionRequest request
+    ) {
+        AuthUserRequestDto authUserRequestDto = AuthUserRequestDto.from(appUser);
+        String editResult = userService.editProfileDescription(
+            authUserRequestDto,
+            request.getDescription()
+        );
+        return ResponseEntity.ok(new ProfileDescriptionResponse(editResult));
     }
 
     @GetMapping("/{username}/contributions")

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileDescriptionRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileDescriptionRequest.java
@@ -1,0 +1,21 @@
+package com.woowacourse.pickgit.user.presentation.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+public class ProfileDescriptionRequest {
+
+    @NotNull
+    private String description;
+
+    private ProfileDescriptionRequest() {
+    }
+
+    public ProfileDescriptionRequest(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileDescriptionRequest.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/request/ProfileDescriptionRequest.java
@@ -1,10 +1,12 @@
 package com.woowacourse.pickgit.user.presentation.dto.request;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public class ProfileDescriptionRequest {
 
     @NotNull
+    @Size(max = 160)
     private String description;
 
     private ProfileDescriptionRequest() {
@@ -15,7 +17,6 @@ public class ProfileDescriptionRequest {
     }
 
     public String getDescription() {
-
         return description;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileDescriptionResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileDescriptionResponse.java
@@ -1,0 +1,17 @@
+package com.woowacourse.pickgit.user.presentation.dto.response;
+
+public class ProfileDescriptionResponse {
+
+    private String description;
+
+    private ProfileDescriptionResponse() {
+    }
+
+    public ProfileDescriptionResponse(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileImageEditResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/dto/response/ProfileImageEditResponse.java
@@ -1,0 +1,17 @@
+package com.woowacourse.pickgit.user.presentation.dto.response;
+
+public class ProfileImageEditResponse {
+
+    private String imageUrl;
+
+    private ProfileImageEditResponse() {
+    }
+
+    public ProfileImageEditResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitProfileStorage.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitProfileStorage.java
@@ -1,0 +1,35 @@
+package com.woowacourse.pickgit.common.mockapi;
+
+import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
+import com.woowacourse.pickgit.user.domain.profile.PickGitProfileStorage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class MockPickGitProfileStorage implements PickGitProfileStorage {
+
+    @Override
+    public Optional<String> store(File file, String userName) {
+        return Optional.ofNullable(file.getName());
+    }
+
+    @Override
+    public String storeByteFile(byte[] file, String userName) {
+        return fileFrom(file).getName();
+    }
+
+    private File fileFrom(byte[] image) {
+        try {
+            Path path = Files.write(
+                Files.createTempFile(null, null),
+                image
+            );
+
+            return path.toFile();
+        } catch (IOException e) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
@@ -23,11 +23,6 @@ public class MockPickGitStorage implements PickGitStorage {
     }
 
     @Override
-    public Optional<String> store(File file, String userName) {
-        return Optional.ofNullable(file.getName());
-    }
-
-    @Override
     public List<String> storeMultipartFile(List<MultipartFile> multipartFiles, String userName) {
         return store(toFiles(multipartFiles), userName);
     }
@@ -55,20 +50,6 @@ public class MockPickGitStorage implements PickGitStorage {
 
             return tempFile.toFile();
         } catch (IOException ioException) {
-            throw new PlatformHttpErrorException();
-        }
-    }
-
-    @Override
-    public File fileFrom(byte[] image) {
-        try {
-            Path path = Files.write(
-                Files.createTempFile(null, null),
-                image
-            );
-
-            return path.toFile();
-        } catch (IOException e) {
             throw new PlatformHttpErrorException();
         }
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockPickGitStorage.java
@@ -58,4 +58,18 @@ public class MockPickGitStorage implements PickGitStorage {
             throw new PlatformHttpErrorException();
         }
     }
+
+    @Override
+    public File fileFrom(byte[] image) {
+        try {
+            Path path = Files.write(
+                Files.createTempFile(null, null),
+                image
+            );
+
+            return path.toFile();
+        } catch (IOException e) {
+            throw new PlatformHttpErrorException();
+        }
+    }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/InfrastructureTestConfiguration.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/InfrastructureTestConfiguration.java
@@ -3,12 +3,14 @@ package com.woowacourse.pickgit.config;
 import com.woowacourse.pickgit.authentication.domain.OAuthClient;
 import com.woowacourse.pickgit.common.mockapi.MockContributionApiRequester;
 import com.woowacourse.pickgit.common.mockapi.MockGithubOAuthClient;
+import com.woowacourse.pickgit.common.mockapi.MockPickGitProfileStorage;
 import com.woowacourse.pickgit.common.mockapi.MockPickGitStorage;
 import com.woowacourse.pickgit.common.mockapi.MockRepositoryApiRequester;
 import com.woowacourse.pickgit.common.mockapi.MockTagApiRequester;
 import com.woowacourse.pickgit.post.domain.repository.PickGitStorage;
 import com.woowacourse.pickgit.post.domain.util.PlatformRepositoryApiRequester;
 import com.woowacourse.pickgit.tag.infrastructure.PlatformTagApiRequester;
+import com.woowacourse.pickgit.user.domain.profile.PickGitProfileStorage;
 import com.woowacourse.pickgit.user.infrastructure.requester.PlatformContributionApiRequester;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +36,11 @@ public class InfrastructureTestConfiguration {
     @Bean
     public PickGitStorage pickGitStorage() {
         return new MockPickGitStorage();
+    }
+
+    @Bean
+    public PickGitProfileStorage pickGitProfileStorage() {
+        return new MockPickGitProfileStorage();
     }
 
     @Bean

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -20,15 +20,20 @@ import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileImageEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileImageEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -420,6 +425,48 @@ class UserServiceIntegrationTest {
         // then
         assertThat(responseDto.getImageUrl()).isEqualTo(user.getImage());
         assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
+    }
+
+    @DisplayName("자신의 프로필 이미지를 수정할 수 있다.")
+    @Test
+    void editProfileImage_LoginUser_Success() throws IOException {
+        // given
+        User user = UserFactory.user("testUser");
+        AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("testUser");
+        File file = FileFactory.getTestImage1File();
+
+        userRepository.save(user);
+
+        // when
+        ProfileImageEditRequestDto requestDto = ProfileImageEditRequestDto
+            .builder()
+            .image(new FileInputStream(file).readAllBytes())
+            .build();
+        ProfileImageEditResponseDto responseDto =
+            userService.editProfileImage(authUserRequestDto, requestDto);
+
+        // then
+        assertThat(responseDto.getImageUrl()).isNotBlank();
+    }
+
+    @DisplayName("자신의 프로필 한 줄 소개를 수정할 수 있다.")
+    @Test
+    void editProfileDescription_LoginUser_Success() {
+        // given
+        User user = UserFactory.user("testUser");
+        AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("testUser");
+        String description = "updated description";
+
+        userRepository.save(user);
+
+        // when
+        String updatedDescription = userService.editProfileDescription(
+            authUserRequestDto,
+            description
+        );
+
+        // then
+        assertThat(updatedDescription).isEqualTo(description);
     }
 
     @DisplayName("로그인 - 저장된 유저중 유사한 이름을 가진 유저를 검색한다. 단, 자기 자신은 검색되지 않는다. (팔로잉한 여부 boolean)")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -21,7 +21,6 @@ import com.woowacourse.pickgit.exception.user.DuplicateFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidFollowException;
 import com.woowacourse.pickgit.exception.user.InvalidUserException;
 import com.woowacourse.pickgit.exception.user.SameSourceTargetUserException;
-import com.woowacourse.pickgit.post.domain.repository.PickGitStorage;
 import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
@@ -38,6 +37,7 @@ import com.woowacourse.pickgit.user.domain.Contribution;
 import com.woowacourse.pickgit.user.domain.PlatformContributionCalculator;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
+import com.woowacourse.pickgit.user.domain.profile.PickGitProfileStorage;
 import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,7 +65,7 @@ class UserServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private PickGitStorage pickGitStorage;
+    private PickGitProfileStorage pickGitProfileStorage;
 
     @Mock
     private PlatformContributionCalculator platformContributionCalculator;
@@ -607,10 +607,8 @@ class UserServiceTest {
             // mock
             given(userRepository.findByBasicProfile_Name("testUser"))
                 .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
-            given(pickGitStorage.fileFrom(imageSource))
-                .willReturn(imageFile);
-            given(pickGitStorage.store(any(File.class), anyString()))
-                .willReturn(Optional.ofNullable(imageFile.getName()));
+            given(pickGitProfileStorage.storeByteFile(imageSource, "testUser"))
+                .willReturn(imageFile.getName());
 
             // when
             ProfileImageEditRequestDto requestDto = ProfileImageEditRequestDto
@@ -625,8 +623,8 @@ class UserServiceTest {
 
             verify(userRepository, times(1))
                 .findByBasicProfile_Name("testUser");
-            verify(pickGitStorage, times(1))
-                .store(any(File.class), anyString());
+            verify(pickGitProfileStorage, times(1))
+                .storeByteFile(imageSource, "testUser");
         }
     }
 
@@ -668,7 +666,7 @@ class UserServiceTest {
         // mock
         given(userRepository.findByBasicProfile_Name("testUser"))
             .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
-        given(pickGitStorage.store(any(File.class), anyString()))
+        given(pickGitProfileStorage.store(any(File.class), anyString()))
             .willReturn(Optional.ofNullable(image.getName()));
 
         // when
@@ -685,7 +683,7 @@ class UserServiceTest {
         assertThat(responseDto.getDescription()).isEqualTo(updatedDescription);
         verify(userRepository, times(1))
             .findByBasicProfile_Name("testUser");
-        verify(pickGitStorage, times(1))
+        verify(pickGitProfileStorage, times(1))
             .store(any(File.class), anyString());
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -26,10 +26,12 @@ import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.application.dto.request.AuthUserRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.FollowSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.ProfileEditRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.ProfileImageEditRequestDto;
 import com.woowacourse.pickgit.user.application.dto.request.UserSearchRequestDto;
 import com.woowacourse.pickgit.user.application.dto.response.ContributionResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.FollowResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.ProfileEditResponseDto;
+import com.woowacourse.pickgit.user.application.dto.response.ProfileImageEditResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserProfileResponseDto;
 import com.woowacourse.pickgit.user.application.dto.response.UserSearchResponseDto;
 import com.woowacourse.pickgit.user.domain.Contribution;
@@ -38,6 +40,8 @@ import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import com.woowacourse.pickgit.user.presentation.dto.request.ContributionRequestDto;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -587,6 +591,68 @@ class UserServiceTest {
             }
         }
     }
+
+    @DisplayName("editProfileImage 메서드는")
+    @Nested
+    class Describe_editProfileImage {
+
+        @DisplayName("새로운 프로필 이미지를 저장소에 업데이트하고 URL을 반환한다.")
+        @Test
+        void editProfileImage_WithImage_Success() throws IOException {
+            // given
+            AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("testUser");
+            File imageFile = FileFactory.getTestImage1File();
+            byte[] imageSource = new FileInputStream(imageFile).readAllBytes();
+
+            // mock
+            given(userRepository.findByBasicProfile_Name("testUser"))
+                .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
+            given(pickGitStorage.store(any(File.class), anyString()))
+                .willReturn(Optional.ofNullable(imageFile.getName()));
+
+            // when
+            ProfileImageEditRequestDto requestDto = ProfileImageEditRequestDto
+                .builder()
+                .image(imageSource)
+                .build();
+            ProfileImageEditResponseDto responseDto =
+                userService.editProfileImage(authUserRequestDto, requestDto);
+
+            // then
+            assertThat(responseDto.getImageUrl()).isEqualTo(imageFile.getName());
+            verify(userRepository, times(1))
+                .findByBasicProfile_Name("testUser");
+            verify(pickGitStorage, times(1))
+                .store(any(File.class), anyString());
+        }
+    }
+
+    @DisplayName("editProfileDescription 메서드는")
+    @Nested
+    class Describe_editProfileDescription {
+
+        @DisplayName("새로운 프로필 한 줄 소개를 저장소에 업데이트한다.")
+        @Test
+        void editProfileDescription_WithDescription_SuccesS() {
+            // given
+            AuthUserRequestDto authUserRequestDto = createLoginAuthUserRequestDto("testUser");
+            String description = "updated description";
+
+            // mock
+            given(userRepository.findByBasicProfile_Name("testUser"))
+                .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
+
+            // when
+            String updatedDescription = userService
+                .editProfileDescription(authUserRequestDto, description);
+
+            // then
+            assertThat(updatedDescription).isEqualTo(description);
+            verify(userRepository, times(1))
+                .findByBasicProfile_Name("testUser");
+        }
+    }
+
 
     @DisplayName("자신의 프로필(이미지, 한 줄 소개 포함)을 수정할 수 있다.")
     @Test

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -607,6 +607,8 @@ class UserServiceTest {
             // mock
             given(userRepository.findByBasicProfile_Name("testUser"))
                 .willReturn(Optional.of(UserFactory.user(1L, "testUser")));
+            given(pickGitStorage.fileFrom(imageSource))
+                .willReturn(imageFile);
             given(pickGitStorage.store(any(File.class), anyString()))
                 .willReturn(Optional.ofNullable(imageFile.getName()));
 
@@ -620,6 +622,7 @@ class UserServiceTest {
 
             // then
             assertThat(responseDto.getImageUrl()).isEqualTo(imageFile.getName());
+
             verify(userRepository, times(1))
                 .findByBasicProfile_Name("testUser");
             verify(pickGitStorage, times(1))


### PR DESCRIPTION
## 상세 내용
- 기존 프로필 수정
  - 멀티파트를 이용하여 이미지 + 내용(한 줄 소개)를 한번에 수정. (POST)
- 변경후 프로필 수정 (API 분리)
  - Body에 이미지 바이트 배열 보내서 수정. (PUT)
  - 내용(한 줄 소개) 수정. (PUT)

<br>

이미지 변경시 아래와 같이 바디에 바이트 배열을 보내서 수정하는 방식입니다.

<img width="970" alt="스크린샷 2021-08-05 오후 3 18 18" src="https://user-images.githubusercontent.com/56860124/128302811-94d5ad05-077a-4593-89de-84581c300c4a.png">

<br>

## 기타
- 바이트 배열을 그대로 받는 것이라서 이미지 수정 부분 restdocs를 어떻게 작성해야 할지 모르겠네요... 더 찾아보고 방법이 있으면 적용해보겠습니다!

<br/>

Close #340
