### PR TITLE
[#359] Github Repositories 검색 기능 구현

### DIFF
--- a/backend/pick-git/src/docs/asciidoc/post.adoc
+++ b/backend/pick-git/src/docs/asciidoc/post.adoc
@@ -97,3 +97,9 @@ include::{snippets}/post-update-Over500Content/http-response.adoc[]
 include::{snippets}/post-delete/http-request.adoc[]
 ==== Response
 include::{snippets}/post-delete/http-response.adoc[]
+
+=== 레포지토리 검색 요청 - 로그인
+==== Request
+include::{snippets}/post-searchRepositories-loggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-searchRepositories-loggedIn/http-response.adoc[]

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -49,6 +49,7 @@ public class OAuthConfiguration implements WebMvcConfigurer {
             authenticationInterceptor())
             .addPathPatterns("/api/posts/me", HttpMethod.GET)
             .addPathPatterns("/api/github/repositories", HttpMethod.GET)
+            .addPathPatterns("/api/github/search/repositories", HttpMethod.GET)
             .addPathPatterns("/api/github/repositories/*/tags/languages", HttpMethod.GET)
             .addPathPatterns("/api/posts", HttpMethod.POST)
             .addPathPatterns("/api/posts/*/likes", HttpMethod.PUT, HttpMethod.DELETE)

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostService.java
@@ -156,6 +156,7 @@ public class PostService {
 
         List<RepositoryNameAndUrl> repositoryNameAndUrls =
             platformRepositorySearchExtractor.extract(token, username, keyword, page, limit);
+
         List<RepositoryResponseDto> repositoryResponseDtos =
             createRepositoryResponsesDto(repositoryNameAndUrls);
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/SearchRepositoryRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/SearchRepositoryRequestDto.java
@@ -12,8 +12,13 @@ public class SearchRepositoryRequestDto {
     private SearchRepositoryRequestDto() {
     }
 
-    public SearchRepositoryRequestDto(String token, String username, String keyword, int page,
-        int limit) {
+    public SearchRepositoryRequestDto(
+        String token,
+        String username,
+        String keyword,
+        int page,
+        int limit
+    ) {
         this.token = token;
         this.username = username;
         this.keyword = keyword;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/SearchRepositoryRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/SearchRepositoryRequestDto.java
@@ -1,0 +1,43 @@
+package com.woowacourse.pickgit.post.application.dto.request;
+
+public class SearchRepositoryRequestDto {
+
+    private String token;
+    private String username;
+    private String keyword;
+    private int page;
+    private int limit;
+
+
+    private SearchRepositoryRequestDto() {
+    }
+
+    public SearchRepositoryRequestDto(String token, String username, String keyword, int page,
+        int limit) {
+        this.token = token;
+        this.username = username;
+        this.keyword = keyword;
+        this.page = page;
+        this.limit = limit;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/util/PlatformRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/util/PlatformRepositorySearchExtractor.java
@@ -6,5 +6,11 @@ import java.util.List;
 
 public interface PlatformRepositorySearchExtractor {
 
-    List<RepositoryNameAndUrl> extract(String token, String username, String keyword, int page, int limit);
+    List<RepositoryNameAndUrl> extract(
+        String token,
+        String username,
+        String keyword,
+        int page,
+        int limit
+    );
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/util/PlatformRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/util/PlatformRepositorySearchExtractor.java
@@ -1,0 +1,10 @@
+package com.woowacourse.pickgit.post.domain.util;
+
+import com.woowacourse.pickgit.post.domain.util.dto.RepositoryNameAndUrl;
+import java.util.List;
+
+
+public interface PlatformRepositorySearchExtractor {
+
+    List<RepositoryNameAndUrl> extract(String token, String username, String keyword, int page, int limit);
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
@@ -36,8 +36,10 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
         int page,
         int limit
     ) {
-        String response = platformRepositoryApiRequester.request(
-            token, generateApiUrl(username, keyword, page + 1, limit)
+        String response =
+            platformRepositoryApiRequester.request(
+                token,
+                generateApiUrl(username, keyword, page + 1, limit)
         );
 
         return parseToRepositories(response);
@@ -49,7 +51,14 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
         int page,
         int limit
     ) {
-        return String.format(API_URL_FORMAT, username, keyword, page, limit);
+
+        return String.format(
+            API_URL_FORMAT,
+            username,
+            keyword,
+            page,
+            limit
+        );
     }
 
     private List<RepositoryNameAndUrl> parseToRepositories(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
@@ -1,0 +1,63 @@
+package com.woowacourse.pickgit.post.infrastructure.extractor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.pickgit.exception.post.RepositoryParseException;
+import com.woowacourse.pickgit.post.domain.util.PlatformRepositoryApiRequester;
+import com.woowacourse.pickgit.post.domain.util.PlatformRepositorySearchExtractor;
+import com.woowacourse.pickgit.post.domain.util.dto.RepositoryNameAndUrl;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GithubRepositorySearchExtractor implements PlatformRepositorySearchExtractor {
+
+    private static final String API_URL_FORMAT =
+        "https://api.github.com/search/repositories?"
+            + "q=user:%s %s in:name fork:true&page=%d&per_page=%d";
+
+    private final ObjectMapper objectMapper;
+    private final PlatformRepositoryApiRequester platformRepositoryApiRequester;
+
+    public GithubRepositorySearchExtractor(
+        ObjectMapper objectMapper,
+        PlatformRepositoryApiRequester platformRepositoryApiRequester
+    ) {
+        this.objectMapper = objectMapper;
+        this.platformRepositoryApiRequester = platformRepositoryApiRequester;
+    }
+
+    @Override
+    public List<RepositoryNameAndUrl> extract(
+        String token,
+        String username,
+        String keyword,
+        int page,
+        int limit
+    ) {
+        String response = platformRepositoryApiRequester.request(
+            token, generateApiUrl(username, keyword, page + 1, limit)
+        );
+
+        return parseToRepositories(response);
+    }
+
+    private String generateApiUrl(
+        String username,
+        String keyword,
+        int page,
+        int limit
+    ) {
+        return String.format(API_URL_FORMAT, username, keyword, page, limit);
+    }
+
+    private List<RepositoryNameAndUrl> parseToRepositories(String response) {
+        try {
+            return objectMapper.readValue(response, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RepositoryParseException();
+        }
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/requester/GithubRepositoryApiRequester.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/requester/GithubRepositoryApiRequester.java
@@ -21,6 +21,7 @@ public class GithubRepositoryApiRequester implements PlatformRepositoryApiReques
     public String request(String token, String url) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setBearerAuth(token);
+        httpHeaders.set("Accept", "application/vnd.github.v3+json");
 
         RequestEntity<Void> requestEntity = RequestEntity
             .get(url)

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
@@ -11,6 +11,7 @@ import com.woowacourse.pickgit.post.application.dto.request.PostDeleteRequestDto
 import com.woowacourse.pickgit.post.application.dto.request.PostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostUpdateRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.RepositoryRequestDto;
+import com.woowacourse.pickgit.post.application.dto.request.SearchRepositoryRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.CommentResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostImageUrlResponseDto;
@@ -139,6 +140,27 @@ public class PostController {
             .page(page)
             .limit(limit)
             .build();
+    }
+
+    @GetMapping("/github/search/repositories")
+    public ResponseEntity<List<RepositoryResponse>> userSearchedRepositories(
+        @Authenticated AppUser user,
+        @RequestParam String keyword,
+        @RequestParam int page,
+        @RequestParam int limit
+    ) {
+        SearchRepositoryRequestDto searchRepositoryRequestDto
+            = new SearchRepositoryRequestDto(
+                user.getAccessToken(), user.getUsername(), keyword, page, limit
+        );
+
+        RepositoryResponsesDto repositoryResponsesDtos =
+            postService.searchUserRepositories(searchRepositoryRequestDto);
+        List<RepositoryResponse> repositoryResponses = toRepositoryResponses(
+            repositoryResponsesDtos.getRepositoryResponsesDto()
+        );
+
+        return ResponseEntity.ok(repositoryResponses);
     }
 
     private List<RepositoryResponse> toRepositoryResponses(

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostRepositorySearchAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostRepositorySearchAcceptanceTest.java
@@ -69,14 +69,13 @@ public class PostRepositorySearchAcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(new TypeRef<>() {
-                });
+                .as(new TypeRef<>() {});
 
         // then
         assertThat(response).hasSize(2);
     }
 
-    @DisplayName("토큰이 없는 경우 예외가 발생한다. - 401 예외")
+    @DisplayName("레포지토리 검색 시 토큰이 없는 경우 예외가 발생한다. - 401 예외")
     @Test
     void searchUserRepositories_InvalidAccessToken_401Exception() {
         // given
@@ -95,8 +94,7 @@ public class PostRepositorySearchAcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
                 .extract()
-                .as(new TypeRef<>() {
-                });
+                .as(new TypeRef<>() {});
 
         assertThat(exception.getErrorCode()).isEqualTo("A0001");
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostRepositorySearchAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostRepositorySearchAcceptanceTest.java
@@ -1,0 +1,138 @@
+package com.woowacourse.pickgit.acceptance.post;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.domain.OAuthClient;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
+import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
+import com.woowacourse.pickgit.post.application.dto.response.RepositoryResponseDto;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(InfrastructureTestConfiguration.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+public class PostRepositorySearchAcceptanceTest {
+
+    private static final String USERNAME = "jipark3";
+
+    @LocalServerPort
+    int port;
+
+    @MockBean
+    private OAuthClient oAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("사용자는 Repository 목록을 키워드 검색으로 가져올 수 있다.")
+    @Test
+    void searchUserRepositories_LoginUser_Success() {
+        // given
+        String token = 로그인_되어있음(USERNAME).getToken();
+        String keyword = "woowa";
+        int page = 0;
+        int limit = 2;
+
+        // when
+        List<RepositoryResponseDto> response =
+            given().log().all()
+                .auth().oauth2(token)
+                .when()
+                .get(
+                    "/api/github/search/repositories?keyword={keyword}&page={page}&limit={limit}",
+                    keyword, page, limit
+                )
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(response).hasSize(2);
+    }
+
+    @DisplayName("토큰이 없는 경우 예외가 발생한다. - 401 예외")
+    @Test
+    void searchUserRepositories_InvalidAccessToken_401Exception() {
+        // given
+        String keyword = "woowa";
+        int page = 0;
+        int limit = 2;
+
+        // when then
+        InvalidTokenException exception =
+            given().log().all()
+                .when()
+                .get(
+                    "/api/github/search/repositories?keyword={keyword}&page={page}&limit={limit}",
+                    keyword, page, limit
+                )
+                .then().log().all()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        assertThat(exception.getErrorCode()).isEqualTo("A0001");
+    }
+
+    private OAuthTokenResponse 로그인_되어있음(String name) {
+        OAuthTokenResponse response = 로그인_요청(name)
+            .as(OAuthTokenResponse.class);
+
+        assertThat(response.getToken()).isNotBlank();
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 로그인_요청(String name) {
+        // given
+        String oauthCode = "1234";
+        String accessToken = "oauth.access.token";
+
+        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
+            name, "image", "hi~", "github.com/",
+            null, null, null, null
+        );
+
+        BDDMockito.given(oAuthClient.getAccessToken(oauthCode))
+            .willReturn(accessToken);
+        BDDMockito.given(oAuthClient.getGithubProfile(accessToken))
+            .willReturn(oAuthProfileResponse);
+
+        // when
+        return given().log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/afterlogin?code=" + oauthCode)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+    }
+
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockRepositoryApiRequester.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockRepositoryApiRequester.java
@@ -30,6 +30,7 @@ public class MockRepositoryApiRequester implements PlatformRepositoryApiRequeste
         if (isInvalidToken(token)) {
             throw new PlatformHttpErrorException("유효하지 않은 외부 플랫폼 토큰");
         }
+
         if (isInvalidUrl(url, userRepoApiUrl, userRepoSearchApiUrl)) {
             throw new PlatformHttpErrorException("유효하지 않은 외부 플랫폼 URL");
         }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockRepositoryApiRequester.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockRepositoryApiRequester.java
@@ -3,32 +3,56 @@ package com.woowacourse.pickgit.common.mockapi;
 import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
 import com.woowacourse.pickgit.post.domain.util.PlatformRepositoryApiRequester;
 
+
 public class MockRepositoryApiRequester implements PlatformRepositoryApiRequester {
 
-    private static final String API_URL_FORMAT = "https://api.github.com/users/%s/repos?page=1&per_page=50";
     private static final String USERNAME = "jipark3";
     private static final String ACCESS_TOKEN = "oauth.access.token";
+    private static final String KEYWORD = "woowa";
+    private static final String API_USER_REPO_URL_FORMAT = "https://api.github.com/users/%s/repos?page=1&per_page=50";
+    private static final String API_SEARCH_USER_REPO_URL_FORMAT =
+        "https://api.github.com/search/repositories?"
+            + "q=user:%s %s in:name fork:true&page=%d&per_page=%d";
 
     @Override
     public String request(String token, String url) {
-        String apiUrl = String.format(API_URL_FORMAT, USERNAME);
+        String userRepoApiUrl =
+            String.format(API_USER_REPO_URL_FORMAT, USERNAME);
+        String userRepoSearchApiUrl =
+            String.format(
+                API_SEARCH_USER_REPO_URL_FORMAT,
+                USERNAME,
+                KEYWORD,
+                1,
+                2
+            );
 
         if (isInvalidToken(token)) {
             throw new PlatformHttpErrorException("유효하지 않은 외부 플랫폼 토큰");
         }
-        if (isInvalidUrl(url, apiUrl)) {
+        if (isInvalidUrl(url, userRepoApiUrl, userRepoSearchApiUrl)) {
             throw new PlatformHttpErrorException("유효하지 않은 외부 플랫폼 URL");
         }
 
-        return "[{\"name\": \"binghe-hi\", \"html_url\": \"https://github.com/jipark3/binghe-hi\"},"
-            + "{\"name\": \"doms-react\", \"html_url\": \"https://github.com/jipark3/doms-react\"}]";
+        if (userRepoApiUrl.equals(url)) {
+            return "[{\"name\": \"binghe-hi\", \"html_url\": \"https://github.com/jipark3/binghe-hi\"},"
+                + "{\"name\": \"doms-react\", \"html_url\": \"https://github.com/jipark3/doms-react\"}]";
+        } else {
+            return "[{\"name\": \"woowa-binghe-hi\", \"html_url\": \"https://github.com/jipark3/woowa-binghe-hi\"},"
+                + "{\"name\": \"woowa-doms-react\", \"html_url\": \"https://github.com/jipark3/woowa-doms-react\"}]";
+        }
     }
 
     private boolean isInvalidToken(String token) {
-        return !ACCESS_TOKEN.equals(token);
+        return !token.equals(ACCESS_TOKEN);
     }
 
-    private boolean isInvalidUrl(String url, String apiUrl) {
-        return !url.equals(apiUrl);
+    private boolean isInvalidUrl(
+        String url,
+        String userRepoApiUrl,
+        String userRepoSearchApiUrl
+    ) {
+        return !url.equals(userRepoApiUrl) &&
+            !url.equals(userRepoSearchApiUrl);
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
@@ -297,7 +297,7 @@ class PostServiceIntegrationTest {
         String invalidToken = "invalidToken";
 
         SearchRepositoryRequestDto requestDto = new SearchRepositoryRequestDto(
-            invalidToken, USERNAME, "woowa", 1, 2
+            invalidToken, USERNAME, "woowa", 0, 2
         );
 
         // then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
@@ -276,9 +276,10 @@ class PostServiceIntegrationTest {
     @Test
     void searchUserRepositories_LoginUser_Success() {
         // given
-        SearchRepositoryRequestDto requestDto = new SearchRepositoryRequestDto(
-            ACCESS_TOKEN, USERNAME, "woowa", 0, 2
-        );
+        SearchRepositoryRequestDto requestDto =
+            new SearchRepositoryRequestDto(
+                ACCESS_TOKEN, USERNAME, "woowa", 0, 2
+            );
 
         // when
         RepositoryResponsesDto repositoryResponsesDto = postService
@@ -296,7 +297,7 @@ class PostServiceIntegrationTest {
         String invalidToken = "invalidToken";
 
         SearchRepositoryRequestDto requestDto = new SearchRepositoryRequestDto(
-            invalidToken, USERNAME, "hello-repo", 1, 2
+            invalidToken, USERNAME, "woowa", 1, 2
         );
 
         // then

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import com.woowacourse.pickgit.post.application.dto.request.PostDeleteRequestDto
 import com.woowacourse.pickgit.post.application.dto.request.PostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostUpdateRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.RepositoryRequestDto;
+import com.woowacourse.pickgit.post.application.dto.request.SearchRepositoryRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.CommentResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostImageUrlResponseDto;
@@ -237,7 +238,7 @@ class PostServiceIntegrationTest {
 
     @DisplayName("토큰이 유효하지 않은 경우 예외가 발생한다. - 500 예외")
     @Test
-    void showRepositories_InvalidAccessToken_401Exception() {
+    void showRepositories_InvalidAccessToken_500Exception() {
         // given
         RepositoryRequestDto requestDto = createRepositoryRequestDto("invalidToken", USERNAME);
 
@@ -248,7 +249,6 @@ class PostServiceIntegrationTest {
             .extracting("errorCode")
             .isEqualTo("V0001");
     }
-
     @DisplayName("사용자가 유효하지 않은 경우 예외가 발생한다. - 500 예외")
     @Test
     void showRepositories_InvalidUsername_404Exception() {
@@ -270,6 +270,41 @@ class PostServiceIntegrationTest {
             .page(0L)
             .limit(50L)
             .build();
+    }
+
+    @DisplayName("사용자는 Repository 목록을 검색해서 가져올 수 있다.")
+    @Test
+    void searchUserRepositories_LoginUser_Success() {
+        // given
+        SearchRepositoryRequestDto requestDto = new SearchRepositoryRequestDto(
+            ACCESS_TOKEN, USERNAME, "woowa", 0, 2
+        );
+
+        // when
+        RepositoryResponsesDto repositoryResponsesDto = postService
+            .searchUserRepositories(requestDto);
+
+        // then
+        assertThat(repositoryResponsesDto.getRepositoryResponsesDto())
+            .hasSize(2);
+    }
+
+    @DisplayName("레포지토리 검색 시 토큰이 유효하지 않은 경우 예외가 발생한다. - 500 예외")
+    @Test
+    void searchUserRepositories_InvalidAccessToken_500Exception() {
+        // given
+        String invalidToken = "invalidToken";
+
+        SearchRepositoryRequestDto requestDto = new SearchRepositoryRequestDto(
+            invalidToken, USERNAME, "hello-repo", 1, 2
+        );
+
+        // then
+        assertThatThrownBy(() -> {
+            postService.searchUserRepositories(requestDto);
+        }).isInstanceOf(PlatformHttpErrorException.class)
+            .extracting("errorCode")
+            .isEqualTo("V0001");
     }
 
     @DisplayName("사용자는 특정 게시물을 좋아요 할 수 있다. - 성공")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest.java
@@ -473,9 +473,10 @@ class PostServiceTest {
         int page = 1;
         int limit = 2;
 
-        SearchRepositoryRequestDto searchRepositoryRequestDto = new SearchRepositoryRequestDto(
-            accessToken, userName, keyword, page, limit
-        );
+        SearchRepositoryRequestDto searchRepositoryRequestDto =
+            new SearchRepositoryRequestDto(
+                accessToken, userName, keyword, page, limit
+            );
 
         given(platformRepositorySearchExtractor
             .extract(
@@ -488,8 +489,9 @@ class PostServiceTest {
         ).willThrow(new RepositoryParseException());
 
         // when then
-        assertThatCode(() -> postService.searchUserRepositories(searchRepositoryRequestDto))
-            .isInstanceOf(RepositoryParseException.class);
+        assertThatCode(() ->
+            postService.searchUserRepositories(searchRepositoryRequestDto)
+        ).isInstanceOf(RepositoryParseException.class);
 
         verify(platformRepositorySearchExtractor, times(1))
             .extract(
@@ -526,8 +528,9 @@ class PostServiceTest {
         ).willThrow(new RepositoryParseException());
 
         // when then
-        assertThatCode(() -> postService.searchUserRepositories(searchRepositoryRequestDto))
-            .isInstanceOf(RepositoryParseException.class);
+        assertThatCode(() ->
+            postService.searchUserRepositories(searchRepositoryRequestDto)
+        ).isInstanceOf(RepositoryParseException.class);
 
         verify(platformRepositorySearchExtractor, times(1))
             .extract(

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
@@ -1,0 +1,97 @@
+package com.woowacourse.pickgit.unit.post.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.pickgit.common.mockapi.MockRepositoryApiRequester;
+import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
+import com.woowacourse.pickgit.post.domain.util.PlatformRepositorySearchExtractor;
+import com.woowacourse.pickgit.post.domain.util.dto.RepositoryNameAndUrl;
+import com.woowacourse.pickgit.post.infrastructure.extractor.GithubRepositorySearchExtractor;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class GithubRepositorySearchExtractorTest {
+
+    private static final String ACCESS_TOKEN = "oauth.access.token";
+    private static final String USERNAME = "jipark3";
+    private static final String KEYWORD = "woowa";
+    private static final int PAGE = 0;
+    private static final int LIMIT = 2;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private PlatformRepositorySearchExtractor platformRepositorySearchExtractor;
+
+    @BeforeEach
+    void setUp() {
+        this.platformRepositorySearchExtractor =
+            new GithubRepositorySearchExtractor(
+                objectMapper, new MockRepositoryApiRequester()
+            );
+    }
+
+    @DisplayName("Github 레포지토리를 검색 키워드와 함께 요청하면 해당 레포지토리 리스트를 반환한다. - 성공")
+    @Test
+    void extract_RepoSearch_Success() {
+        // given
+        List<RepositoryNameAndUrl> expectedResponse =
+            List.of(
+                new RepositoryNameAndUrl("woowa-binghe-hi", "https://github.com/jipark3/woowa-binghe-hi"),
+                new RepositoryNameAndUrl("woowa-doms-react", "https://github.com/jipark3/woowa-doms-react")
+            );
+
+        // when
+        List<RepositoryNameAndUrl> response = platformRepositorySearchExtractor.extract(
+            ACCESS_TOKEN,
+            USERNAME,
+            KEYWORD,
+            PAGE,
+            LIMIT
+        );
+
+        // then
+        assertThat(response)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("유효하지 않은 토큰 일 경우 예외가 발생한다. - 500 예외")
+    @Test
+    void extract_InvalidToken_500Exception() {
+        // given when
+        String invalidToken = "Invalid Token";
+
+        // then
+        assertThatThrownBy(() ->
+            platformRepositorySearchExtractor.extract(
+                invalidToken, USERNAME, KEYWORD, PAGE, LIMIT
+            )
+        ).isInstanceOf(PlatformHttpErrorException.class)
+            .hasFieldOrPropertyWithValue(
+                "errorCode", "V0001"
+            );
+
+    }
+
+    @DisplayName("유효하지 않은 유저 일 경우 예외가 발생한다. - 500 예외")
+    @Test
+    void extract_InvalidUser_500Exception() {
+        // given when
+        String invalidUser = "Invalid User";
+
+        // then
+        assertThatThrownBy(() ->
+            platformRepositorySearchExtractor.extract(
+                ACCESS_TOKEN, invalidUser, KEYWORD, PAGE, LIMIT
+            )
+        ).isInstanceOf(PlatformHttpErrorException.class)
+            .hasFieldOrPropertyWithValue(
+                "errorCode", "V0001"
+            );
+
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
@@ -323,7 +323,7 @@ class PostControllerTest {
         ));
     }
 
-    @DisplayName("사용자는 Repository 목록을 검색할 수 있다.")
+    @DisplayName("사용자는 Repository 목록을 검색할 수 있다. - 성공")
     @Test
     void userSearchedRepositories_LoginUser_Success() throws Exception {
         // given


### PR DESCRIPTION
## 상세 내용
- Post 업로드 시 사용자의 레포지토리를 검색을 통해 가지고 오는 기능을 구현한다.
- Pagination을 적용한다.
- 사용자의 Keyword를 통해서 Github API 에 해당 단어를 포함하는 레포지토리를 모두 조회하여 반환한다.

- 예외 케이스
1. Github에 보내어지는 Access Token이 invalid 할 경우 예외 방생
2. Github에 존재하지 않는 username 계정의 repo 검색 시 예외 발생
<br/>

## 기타
현재 이전에 말했듯이 `PlatformApiRequester`를 공유하고 있는데, 그래서 테스트에서도 `MockRepositoryApiRequest`를 의존하고 있어요! 그런데 현재 `MockRepositoryApiRequest`가 굉장히 특정 유저의 Repository를 조회하는 쪽으로 구현이 되어 있어서 거기에 Github repo를 검색하는 로직을 끼워넣으려다 보니까 코드가 상당히 지저분해 진 것 같아요.

<img width=80% alt="스크린샷 2021-08-06 오후 3 40 20" src="https://user-images.githubusercontent.com/63405904/128467569-d07e5050-4954-4ac8-a3a3-314171ff39cd.png">

따로 `MockRepositoryApiRequest`를 작성하려다보니 프로덕션 코드에는 두 requester가 분리되어 있지 않아서 자동으로 주입을 해줄 수 가 없는 상황입니다. 아마 `MockRepositoryApiRequest` 코드를 개선하는 방법을 찾아야 하는 것 같은데 이전 레포지토리 조회 코드와 깊게 연관이 되어 있어서 우선은 그냥 올립니다!  
<br/>

Close #359 
