### PR TITLE
[#355] 홈 피드를 새로운 기준으로 정렬

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostDtoAssembler.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostDtoAssembler.java
@@ -8,6 +8,7 @@ import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
 import com.woowacourse.pickgit.post.domain.Post;
 import com.woowacourse.pickgit.user.domain.User;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class PostDtoAssembler {
@@ -17,15 +18,14 @@ public class PostDtoAssembler {
 
     public static List<PostResponseDto> assembleFrom(
         User requestUser,
-        boolean isGuest,
         List<Post> posts
     ) {
         return posts.stream()
-            .map(post -> convertFrom(requestUser, isGuest, post))
+            .map(post -> convertFrom(requestUser, post))
             .collect(toList());
     }
 
-    private static PostResponseDto convertFrom(User requestUser, boolean isGuest, Post post) {
+    private static PostResponseDto convertFrom(User requestUser, Post post) {
         List<String> tags = createTagsFrom(post);
         List<CommentResponseDto> comments = createCommentResponsesFrom(post);
 
@@ -41,7 +41,7 @@ public class PostDtoAssembler {
             .createdAt(post.getCreatedAt())
             .updatedAt(post.getUpdatedAt())
             .comments(comments)
-            .liked(isLikedBy(requestUser, post, isGuest))
+            .liked(isLikedBy(requestUser, post))
             .build();
     }
 
@@ -67,8 +67,8 @@ public class PostDtoAssembler {
         return post.getTagNames();
     }
 
-    private static Boolean isLikedBy(User requestUser, Post post, boolean isGuest) {
-        if (isGuest) {
+    private static Boolean isLikedBy(User requestUser, Post post) {
+        if (Objects.isNull(requestUser)) {
             return null;
         }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
@@ -16,8 +16,6 @@ import com.woowacourse.pickgit.post.domain.repository.PostRepository;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -42,45 +40,45 @@ public class PostFeedService {
     }
 
     public List<PostResponseDto> homeFeed(HomeFeedRequestDto homeFeedRequestDto) {
-        return readFeed(homeFeedRequestDto, Optional.empty());
+        Pageable pageable = getPagination(homeFeedRequestDto);
+        if (homeFeedRequestDto.isGuest()) {
+            return PostDtoAssembler.assembleFrom(null,  postRepository.findAllPosts(pageable));
+        }
+        User requestUser = findUserByName(homeFeedRequestDto.getRequestUserName());
+        List<Post> result = postRepository.findAllAssociatedPostsByUser(requestUser, pageable);
+        return PostDtoAssembler.assembleFrom(requestUser, result);
     }
 
     public List<PostResponseDto> myFeed(HomeFeedRequestDto homeFeedRequestDto) {
-        String userName = homeFeedRequestDto.getRequestUserName();
-
-        if (Objects.isNull(userName)) {
+        if (homeFeedRequestDto.isGuest()) {
             throw new UnauthorizedException();
         }
-
-        return readFeed(homeFeedRequestDto, Optional.of(userName));
+        return readUserFeed(homeFeedRequestDto, homeFeedRequestDto.getRequestUserName());
     }
 
     public List<PostResponseDto> userFeed(HomeFeedRequestDto homeFeedRequestDto, String userName) {
-        return readFeed(homeFeedRequestDto, Optional.of(userName));
+        return readUserFeed(homeFeedRequestDto, userName);
     }
 
-    private List<PostResponseDto> readFeed(
+    private List<PostResponseDto> readUserFeed(
         HomeFeedRequestDto homeFeedRequestDto,
-        Optional<String> userName
+        String targetUserName
     ) {
-        int page = homeFeedRequestDto.getPage().intValue();
-        int limit = homeFeedRequestDto.getLimit().intValue();
-        String requestUserName = homeFeedRequestDto.getRequestUserName();
-        boolean isGuest = homeFeedRequestDto.isGuest();
-
-        Pageable pageable = PageRequest.of(page, limit);
-        List<Post> result = getPostsBy(userName, pageable);
-
-        User requestUser = findUserByName(requestUserName);
-
-        return PostDtoAssembler.assembleFrom(requestUser, isGuest, result);
+        Pageable pageable = getPagination(homeFeedRequestDto);
+        User target = findUserByName(targetUserName);
+        List<Post> result = postRepository.findAllPostsByUser(target, pageable);
+        if (homeFeedRequestDto.isGuest()) {
+            return PostDtoAssembler.assembleFrom(null, result);
+        }
+        User requestUser = findUserByName(homeFeedRequestDto.getRequestUserName());
+        return PostDtoAssembler.assembleFrom(requestUser, result);
     }
 
-    private List<Post> getPostsBy(Optional<String> userName, Pageable pageable) {
-        return userName
-            .map(this::findUserByName)
-            .map(target -> postRepository.findAllPostsByUser(target, pageable))
-            .orElse(postRepository.findAllPosts(pageable));
+    private PageRequest getPagination(HomeFeedRequestDto homeFeedRequestDto) {
+        return PageRequest.of(
+            homeFeedRequestDto.getPage().intValue(),
+            homeFeedRequestDto.getLimit().intValue()
+        );
     }
 
     public List<PostResponseDto> search(SearchPostsRequestDto searchPostsRequestDto) {
@@ -101,10 +99,6 @@ public class PostFeedService {
     }
 
     private User findUserByName(String userName) {
-        if(Objects.isNull(userName)) {
-            return null;
-        }
-
         return userRepository
             .findByBasicProfile_Name(userName)
             .orElseThrow(UserNotFoundException::new);

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PostRepository.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PostRepository.java
@@ -22,4 +22,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("select distinct p from Post p left join fetch p.likes.likes l left join fetch l.user where p.id = :postId")
     Optional<Post> findPostWithLikeUsers(@Param("postId") Long postId);
+
+    @Query("select p from Post p join fetch p.user u "
+        + "where u in "
+        + "(select t from Follow f inner join f.target t on f.source = :user) "
+        + "or u = :user "
+        + "order by p .createdAt desc")
+    List<Post> findAllAssociatedPostsByUser(@Param("user") User user, Pageable pageable);
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest.java
@@ -163,9 +163,9 @@ class PostAcceptanceTest {
         assertThat(response.getErrorCode()).isEqualTo("P0001");
     }
 
-    @DisplayName("로그인일때 게시물을 조회한다. - 댓글 및 게시글의 좋아요 여부를 확인할 수 있다.")
+    @DisplayName("로그인일때 홈 피드를 조회한다. - 게시글 좋아요 여부 true/false")
     @Test
-    void read_LoginUser_Success() {
+    void readHomeFeed_LoginUser_Success() {
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();
 
         requestToWritePostApi(token, HttpStatus.CREATED);
@@ -188,7 +188,7 @@ class PostAcceptanceTest {
             .containsExactly(false, false, false);
     }
 
-    @DisplayName("비 로그인이어도 게시글 조회가 가능하다. - Comment 및 게시물 좋아요 여부는 항상 false")
+    @DisplayName("비 로그인이어도 홈 피드 조회가 가능하다. - 게시물 좋아요 여부는 항상 null")
     @Test
     void read_GuestUser_Success() {
         String token = 로그인_되어있음(ANOTHER_USERNAME).getToken();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_searchPost.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_searchPost.java
@@ -61,7 +61,7 @@ public class PostAcceptanceTest_searchPost {
     private void createPost(String... tags) {
         int statusCode = PickGitRequest.post("/api/posts")
             .api_posts()
-            .withUser()
+            .withUser("testUser")
             .initAllParams()
             .tags(tags)
             .extract().statusCode();
@@ -71,7 +71,7 @@ public class PostAcceptanceTest_searchPost {
 
     private List<PostResponse> getAllPostsWithUser(int size) {
         return PickGitRequest.get("/api/posts?page={page}&limit={limit}", 0, size)
-            .withUser()
+            .withUser("testUser")
             .extract()
             .as(new TypeRef<>() {
             });
@@ -92,7 +92,7 @@ public class PostAcceptanceTest_searchPost {
         ExtractableResponse<Response> extract = PickGitRequest
             .get("/api/search/posts?type=tags&keyword={keyword}&page={page}&limit={limit}",
                 keyword, page, limit
-            ).withUser()
+            ).withUser("testUser")
             .extract();
 
         assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
@@ -7,6 +7,7 @@ import com.woowacourse.pickgit.post.domain.Post;
 import com.woowacourse.pickgit.post.domain.like.Likes;
 import com.woowacourse.pickgit.user.domain.User;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.mockito.Mock;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,6 +19,33 @@ public class PostFactory {
 
     public static class Builder {
 
+    }
+
+    public static Post mockPostBy(User user) {
+        return Post.builder()
+            .content("mock post content")
+            .author(user)
+            .githubRepoUrl("mock-url")
+            .images(new ArrayList<>())
+            .tags(new ArrayList<>())
+            .build();
+    }
+
+    public static List<Post> mockPostsBy(List<User> users) {
+        List<Post> posts = new ArrayList<>();
+        int userCounts = users.size();
+        for (int i = 0; i < userCounts; i++) {
+            posts.add(
+                Post.builder()
+                    .content("abc" + i)
+                    .author(users.get(i))
+                    .githubRepoUrl("url" + i)
+                    .images(new ArrayList<>())
+                    .tags(new ArrayList<>())
+                    .build()
+            );
+        }
+        return posts;
     }
 
     public static List<PostRequestDto> mockPostRequestDtos() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
@@ -152,7 +152,42 @@ public class PostFactory {
         return List.of(fixture1, fixture2, fixture3, fixture4, fixture5);
     }
 
-    public static List<PostResponseDto> mockPostResponseDtos() {
+    public static List<PostResponseDto> mockPostResponseDtosForGuest() {
+        CommentResponseDto commentFixture1 = CommentResponseDto.builder()
+            .id(1L)
+            .profileImageUrl("commentAuthorProfileImageUrl")
+            .authorName("commentAuthorName1")
+            .content("commentContent1")
+            .liked(null)
+            .build();
+
+        CommentResponseDto commentFixture2 = CommentResponseDto.builder()
+            .id(2L)
+            .profileImageUrl("commentAuthorProfileImageUrl")
+            .authorName("commentAuthorName2")
+            .content("commentContent2")
+            .liked(null)
+            .build();
+
+        PostResponseDto fixture1 = PostResponseDto.builder()
+            .id(1L)
+            .imageUrls(List.of("image1Url", "image2Url"))
+            .githubRepoUrl("githubRepoUrl")
+            .content("content")
+            .authorName("authorName")
+            .profileImageUrl("profileImageUrl")
+            .likesCount(1)
+            .tags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .comments(List.of(commentFixture1, commentFixture2))
+            .liked(null)
+            .build();
+
+        return List.of(fixture1);
+    }
+
+    public static List<PostResponseDto> mockPostResponseDtosForLogin() {
         CommentResponseDto commentFixture1 = CommentResponseDto.builder()
             .id(1L)
             .profileImageUrl("commentAuthorProfileImageUrl")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest.java
@@ -2,9 +2,11 @@ package com.woowacourse.pickgit.integration.post;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.woowacourse.pickgit.comment.application.CommentService;
 import com.woowacourse.pickgit.comment.application.dto.request.CommentRequestDto;
+import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.common.factory.PostFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
@@ -13,6 +15,9 @@ import com.woowacourse.pickgit.post.application.PostService;
 import com.woowacourse.pickgit.post.application.dto.request.HomeFeedRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.repository.PostRepository;
+import com.woowacourse.pickgit.user.application.UserService;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import java.util.List;
@@ -31,7 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
 @Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
-public class PostFeedServiceIntegrationTest {
+class PostFeedServiceIntegrationTest {
 
     @Autowired
     private PostService postService;
@@ -43,18 +48,22 @@ public class PostFeedServiceIntegrationTest {
     private PostFeedService postFeedService;
 
     @Autowired
+    private UserService userService;
+
+    @Autowired
     private UserRepository userRepository;
 
-    @DisplayName("저장된 게시물 중 3, 4번째 글을 최신날짜순으로 가져온다.")
-    @Test
-    void readHomeFeed_Success() {
-        //given
-        createMockPosts();
+    @Autowired
+    private PostRepository postRepository;
 
-        userRepository.save(UserFactory.user("kevin"));
+    @DisplayName("비로그인 홈피드 - 전체 게시물 중 3, 4번째 글을 최신순으로 가져온다. (좋아요 여부 null)")
+    @Test
+    void readHomeFeed_Guest_LatestPosts() {
+        // given
+        createMockPosts();
         HomeFeedRequestDto homeFeedRequestDto = HomeFeedRequestDto.builder()
-            .requestUserName("kevin")
-            .isGuest(false)
+            .requestUserName(null)
+            .isGuest(true)
             .page(1L)
             .limit(2L)
             .build();
@@ -62,16 +71,54 @@ public class PostFeedServiceIntegrationTest {
         // when
         List<PostResponseDto> postResponseDtos = postFeedService.homeFeed(homeFeedRequestDto);
 
-        //then
-        List<String> postNames = postResponseDtos.stream()
-            .map(PostResponseDto::getAuthorName)
-            .collect(toList());
+        // then
+        assertThat(postResponseDtos)
+            .extracting("authorName", "githubRepoUrl", "liked")
+            .containsExactly(
+                tuple("dani", "java-racingcar", null),
+                tuple("ginger", "jwp-chess", null)
+            );
+    }
 
-        List<String> repoNames = extractGithubRepoUrls(postResponseDtos);
+    @DisplayName("로그인 홈피드 - 내가 팔로잉하는 사람들과 내 글을 최신순으로 가져온다. (좋아요 여부 true/false)")
+    @Test
+    void readHomeFeed_Login_FollowingsLatestPosts() {
+        // given
+        HomeFeedRequestDto homeFeedRequestDto = HomeFeedRequestDto.builder()
+            .requestUserName("kevin")
+            .isGuest(false)
+            .page(0L)
+            .limit(10L)
+            .build();
+        AuthUserRequestDto authDto = AuthUserRequestDto.from(new LoginUser("kevin", "token"));
 
-        assertThat(postResponseDtos).hasSize(2);
-        assertThat(postNames).containsExactly("dani", "ginger");
-        assertThat(repoNames).containsExactly("java-racingcar", "jwp-chess");
+        User requester = userRepository.save(UserFactory.user("kevin"));
+        List<User> mockUsers = userRepository.saveAll(UserFactory.mockSearchUsers());
+
+        postRepository.save(PostFactory.mockPostBy(requester));
+        List<Post> mockPostsBy = postRepository.saveAll(PostFactory.mockPostsBy(mockUsers));
+
+        for (User mockUser : mockUsers) {
+            userService.followUser(authDto, mockUser.getName());
+        }
+        for (int i = 0; i < mockPostsBy.size(); i += 2) {
+            postService.like(new LoginUser("kevin", "token"), mockPostsBy.get(i).getId());
+        }
+
+        // when
+        List<PostResponseDto> postResponseDtos = postFeedService.homeFeed(homeFeedRequestDto);
+
+        // then
+        assertThat(postResponseDtos)
+            .extracting("authorName", "githubRepoUrl", "liked")
+            .containsExactly(
+                tuple("bingbing", "url4", true),
+                tuple("bbbbinghe", "url3", false),
+                tuple("jinbinghe", "url2", true),
+                tuple("bing", "url1", false),
+                tuple("binghe", "url0", true),
+                tuple("kevin", "mock-url", false)
+            );
     }
 
     private void createMockPosts() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest.java
@@ -4,9 +4,9 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.comment.application.CommentService;
 import com.woowacourse.pickgit.comment.application.dto.request.CommentRequestDto;
-import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.common.factory.PostFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
@@ -18,6 +18,8 @@ import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
 import com.woowacourse.pickgit.post.domain.Post;
 import com.woowacourse.pickgit.post.domain.repository.PostRepository;
 import com.woowacourse.pickgit.user.application.UserService;
+import com.woowacourse.pickgit.user.application.dto.request.AuthUserForUserRequestDto;
+import com.woowacourse.pickgit.user.application.dto.request.FollowRequestDto;
 import com.woowacourse.pickgit.user.domain.User;
 import com.woowacourse.pickgit.user.domain.UserRepository;
 import java.util.List;
@@ -90,7 +92,7 @@ class PostFeedServiceIntegrationTest {
             .page(0L)
             .limit(10L)
             .build();
-        AuthUserRequestDto authDto = AuthUserRequestDto.from(new LoginUser("kevin", "token"));
+        AuthUserForUserRequestDto authDto = AuthUserForUserRequestDto.from(new LoginUser("kevin", "token"));
 
         User requester = userRepository.save(UserFactory.user("kevin"));
         List<User> mockUsers = userRepository.saveAll(UserFactory.mockSearchUsers());
@@ -99,7 +101,7 @@ class PostFeedServiceIntegrationTest {
         List<Post> mockPostsBy = postRepository.saveAll(PostFactory.mockPostsBy(mockUsers));
 
         for (User mockUser : mockUsers) {
-            userService.followUser(authDto, mockUser.getName());
+            userService.followUser(new FollowRequestDto(authDto, mockUser.getName(), false));
         }
         for (int i = 0; i < mockPostsBy.size(); i += 2) {
             postService.like(new LoginUser("kevin", "token"), mockPostsBy.get(i).getId());

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_search.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_search.java
@@ -109,7 +109,7 @@ public class PostFeedServiceIntegrationTest_search {
         // then
         List<Post> allPosts = postRepository.findAll();
         List<PostResponseDto> allPostResponseDtos = PostDtoAssembler
-            .assembleFrom(user, false, allPosts);
+            .assembleFrom(user, allPosts);
         List<PostResponseDto> expected = findPostResponseByTags(allPostResponseDtos, keyword);
 
         assertThat(actual)
@@ -132,7 +132,7 @@ public class PostFeedServiceIntegrationTest_search {
         // then
         List<Post> allPosts = postRepository.findAll();
         List<PostResponseDto> allPostResponseDtos = PostDtoAssembler
-            .assembleFrom(null, true, allPosts);
+            .assembleFrom(null, allPosts);
         List<PostResponseDto> expected = findPostResponseByTags(allPostResponseDtos, keyword);
 
         assertThat(actual)

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostFeedService_search.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostFeedService_search.java
@@ -71,7 +71,7 @@ public class PostFeedService_search {
 
         assertThat(actual)
             .usingRecursiveComparison()
-            .isEqualTo(PostDtoAssembler.assembleFrom(requestUser, false, List.of(post)));
+            .isEqualTo(PostDtoAssembler.assembleFrom(requestUser, List.of(post)));
 
         verify(searchTypes, times(1))
             .findByTypeName(type);
@@ -104,7 +104,7 @@ public class PostFeedService_search {
         // then
         assertThat(actual)
             .usingRecursiveComparison()
-            .isEqualTo(PostDtoAssembler.assembleFrom(null, true, List.of(post)));
+            .isEqualTo(PostDtoAssembler.assembleFrom(null, List.of(post)));
 
         verify(searchTypes, times(1))
             .findByTypeName(type);

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -204,49 +204,6 @@ class PostRepositoryTest {
             .containsExactly("tester", "a7", "a5", "a3", "a1");
     }
 
-    @DisplayName("전체 게시물을 최신순으로 가져온다.")
-    @Test
-    void findAllPostsByUser_FollowingsNotConcerned_Success() {
-        // given - mockUsers
-        User tester = UserFactory.user("tester");
-        List<User> mockUsers = List.of(
-            UserFactory.user("a1"),
-            UserFactory.user("a2"),
-            UserFactory.user("a3"),
-            UserFactory.user("a4"),
-            UserFactory.user("a5"),
-            UserFactory.user("a6"),
-            UserFactory.user("a7"),
-            UserFactory.user("a8")
-        );
-        userRepository.save(tester);
-        userRepository.saveAll(mockUsers);
-
-        // given - follow
-        int mockUserCounts = mockUsers.size();
-        for (int i = 0; i < mockUserCounts; i += 2) {
-            tester.follow(mockUsers.get(i));
-        }
-
-        // given - mockPosts
-        List<Post> mockPosts = PostFactory.mockPostsBy(mockUsers);
-        Post testerPost = PostFactory.mockPostBy(tester);
-        postRepository.saveAll(mockPosts);
-        postRepository.save(testerPost);
-
-        flushAndClear();
-
-        // when
-        List<Post> feeds = postRepository.findAllPosts(PageRequest.of(0, 10));
-
-        // then
-        assertThat(feeds)
-            .extracting("user")
-            .extracting("basicProfile")
-            .extracting("name")
-            .containsExactly("tester", "a8", "a7", "a6", "a5", "a4", "a3", "a2", "a1");
-    }
-
     private void flushAndClear() {
         testEntityManager.flush();
         testEntityManager.clear();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -204,6 +204,49 @@ class PostRepositoryTest {
             .containsExactly("tester", "a7", "a5", "a3", "a1");
     }
 
+    @DisplayName("전체 게시물을 최신순으로 가져온다.")
+    @Test
+    void findAllPostsByUser_FollowingsNotConcerned_Success() {
+        // given - mockUsers
+        User tester = UserFactory.user("tester");
+        List<User> mockUsers = List.of(
+            UserFactory.user("a1"),
+            UserFactory.user("a2"),
+            UserFactory.user("a3"),
+            UserFactory.user("a4"),
+            UserFactory.user("a5"),
+            UserFactory.user("a6"),
+            UserFactory.user("a7"),
+            UserFactory.user("a8")
+        );
+        userRepository.save(tester);
+        userRepository.saveAll(mockUsers);
+
+        // given - follow
+        int mockUserCounts = mockUsers.size();
+        for (int i = 0; i < mockUserCounts; i += 2) {
+            tester.follow(mockUsers.get(i));
+        }
+
+        // given - mockPosts
+        List<Post> mockPosts = PostFactory.mockPostsBy(mockUsers);
+        Post testerPost = PostFactory.mockPostBy(tester);
+        postRepository.saveAll(mockPosts);
+        postRepository.save(testerPost);
+
+        flushAndClear();
+
+        // when
+        List<Post> feeds = postRepository.findAllPosts(PageRequest.of(0, 10));
+
+        // then
+        assertThat(feeds)
+            .extracting("user")
+            .extracting("basicProfile")
+            .extracting("name")
+            .containsExactly("tester", "a8", "a7", "a6", "a5", "a4", "a3", "a2", "a1");
+    }
+
     private void flushAndClear() {
         testEntityManager.flush();
         testEntityManager.clear();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -132,34 +132,6 @@ class PostRepositoryTest {
             .isInstanceOf(InvalidDataAccessApiUsageException.class);
     }
 
-    @DisplayName("Post에 Comment를 추가하면 Comment가 자동 영속화된다.")
-    @Test
-    void addComment_WhenSavingPost_CommentSavedTogether() {
-        // given
-        User testUser = UserFactory.user("testUser");
-        User savedTestUser = userRepository.save(testUser);
-
-        Post post = Post.builder()
-            .content("testContent")
-            .githubRepoUrl("https://github.com/bperhaps")
-            .author(savedTestUser)
-            .build();
-
-        // when
-        Comment comment = new Comment("test comment", testUser);
-        post.addComment(comment);
-
-        postRepository.save(post);
-        flushAndClear();
-
-        // then
-        Post findPost = postRepository.findById(post.getId())
-            .orElseThrow(IllegalArgumentException::new);
-
-        List<Comment> comments = findPost.getComments();
-        assertThat(comments).hasSize(1);
-    }
-
     @DisplayName("나를 포함하여 내가 팔로잉하는 유저들의 게시글을 최신순으로 가져온다.")
     @Test
     void findAllAssociatedPostsByUser_FollowingsLatestIncludingMe_Success() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.pickgit.unit.post.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.pickgit.common.factory.PostFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.JpaTestConfiguration;
 import com.woowacourse.pickgit.post.domain.Post;
@@ -21,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.PageRequest;
 
 @Import(JpaTestConfiguration.class)
 @DataJpaTest
@@ -128,6 +130,78 @@ class PostRepositoryTest {
         post.addTags(tags);
         assertThatThrownBy(() -> postRepository.save(post))
             .isInstanceOf(InvalidDataAccessApiUsageException.class);
+    }
+
+    @DisplayName("Post에 Comment를 추가하면 Comment가 자동 영속화된다.")
+    @Test
+    void addComment_WhenSavingPost_CommentSavedTogether() {
+        // given
+        User testUser = UserFactory.user("testUser");
+        User savedTestUser = userRepository.save(testUser);
+
+        Post post = Post.builder()
+            .content("testContent")
+            .githubRepoUrl("https://github.com/bperhaps")
+            .author(savedTestUser)
+            .build();
+
+        // when
+        Comment comment = new Comment("test comment", testUser);
+        post.addComment(comment);
+
+        postRepository.save(post);
+        flushAndClear();
+
+        // then
+        Post findPost = postRepository.findById(post.getId())
+            .orElseThrow(IllegalArgumentException::new);
+
+        List<Comment> comments = findPost.getComments();
+        assertThat(comments).hasSize(1);
+    }
+
+    @DisplayName("나를 포함하여 내가 팔로잉하는 유저들의 게시글을 최신순으로 가져온다.")
+    @Test
+    void findAllAssociatedPostsByUser_FollowingsLatestIncludingMe_Success() {
+        // given - mockUsers
+        User tester = UserFactory.user("tester");
+        List<User> mockUsers = List.of(
+            UserFactory.user("a1"),
+            UserFactory.user("a2"),
+            UserFactory.user("a3"),
+            UserFactory.user("a4"),
+            UserFactory.user("a5"),
+            UserFactory.user("a6"),
+            UserFactory.user("a7"),
+            UserFactory.user("a8")
+        );
+        userRepository.save(tester);
+        userRepository.saveAll(mockUsers);
+
+        // given - follow
+        int mockUserCounts = mockUsers.size();
+        for (int i = 0; i < mockUserCounts; i += 2) {
+            tester.follow(mockUsers.get(i));
+        }
+
+        // given - mockPosts
+        List<Post> mockPosts = PostFactory.mockPostsBy(mockUsers);
+        Post testerPost = PostFactory.mockPostBy(tester);
+        postRepository.saveAll(mockPosts);
+        postRepository.save(testerPost);
+
+        flushAndClear();
+
+        // when
+        List<Post> feeds =
+            postRepository.findAllAssociatedPostsByUser(tester, PageRequest.of(0, 10));
+
+        // then
+        assertThat(feeds)
+            .extracting("user")
+            .extracting("basicProfile")
+            .extracting("name")
+            .containsExactly("tester", "a7", "a5", "a3", "a1");
     }
 
     private void flushAndClear() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest_search.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest_search.java
@@ -66,7 +66,7 @@ public class PostRepositoryTest_search {
         List<Post> savedPosts = postRepository.findAllPostsByTagNames(keywords, pageRequest);
 
         List<PostResponseDto> actual =
-            PostDtoAssembler.assembleFrom(user, false, savedPosts);
+            PostDtoAssembler.assembleFrom(user, savedPosts);
 
         actual.sort(comparing(PostResponseDto::getAuthorName));
         expected.sort(comparing(PostResponseDto::getAuthorName));
@@ -125,7 +125,7 @@ public class PostRepositoryTest_search {
             user,
             List.of(tags),
             keyword,
-            PostDtoAssembler.assembleFrom(user, false, expected)
+            PostDtoAssembler.assembleFrom(user, expected)
         );
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -40,7 +41,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @Import(InfrastructureTestConfiguration.class)
 @WebMvcTest(PostFeedController.class)
 @ActiveProfiles("test")
-public class PostFeedControllerTest {
+class PostFeedControllerTest {
 
     private static final String API_ACCESS_TOKEN = "oauth.access.token";
 
@@ -60,7 +61,7 @@ public class PostFeedControllerTest {
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(new GuestUser());
         given(postfeedService.homeFeed(any(HomeFeedRequestDto.class)))
-            .willReturn(PostFactory.mockPostResponseDtos());
+            .willReturn(PostFactory.mockPostResponseDtosForGuest());
 
         // when
         ResultActions perform = mockMvc.perform(get("/api/posts")
@@ -95,8 +96,8 @@ public class PostFeedControllerTest {
                     .description("댓글 작성자 프로필 사진"),
                 fieldWithPath("[].comments[].authorName").type(STRING).description("댓글 작성자 이름"),
                 fieldWithPath("[].comments[].content").type(STRING).description("댓글 내용"),
-                fieldWithPath("[].comments[].liked").type(BOOLEAN).description("댓글 좋아요 여부"),
-                fieldWithPath("[].liked").type(BOOLEAN).description("좋아요 여부")
+                fieldWithPath("[].comments[].liked").type(NULL).description("댓글 좋아요 여부"),
+                fieldWithPath("[].liked").type(NULL).description("좋아요 여부")
             )
             )
         );
@@ -114,7 +115,7 @@ public class PostFeedControllerTest {
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(loginUser);
         given(postfeedService.homeFeed(any(HomeFeedRequestDto.class)))
-            .willReturn(PostFactory.mockPostResponseDtos());
+            .willReturn(PostFactory.mockPostResponseDtosForLogin());
 
         // when
         ResultActions perform = mockMvc.perform(get("/api/posts")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_searchPosts.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_searchPosts.java
@@ -95,7 +95,7 @@ public class PostFeedControllerTest_searchPosts {
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(new GuestUser());
         given(postFeedService.search(any(SearchPostsRequestDto.class)))
-            .willReturn(PostDtoAssembler.assembleFrom(null, true, List.of(post1, post2)));
+            .willReturn(PostDtoAssembler.assembleFrom(null,  List.of(post1, post2)));
 
         ResultActions perform = mockMvc.perform(
             get("/api/search/posts")
@@ -143,7 +143,7 @@ public class PostFeedControllerTest_searchPosts {
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(new GuestUser());
         given(postFeedService.search(any(SearchPostsRequestDto.class)))
-            .willReturn(PostDtoAssembler.assembleFrom(user, false, List.of(post1, post2)));
+            .willReturn(PostDtoAssembler.assembleFrom(user, List.of(post1, post2)));
 
         ResultActions perform = mockMvc.perform(
             get("/api/search/posts")


### PR DESCRIPTION
## 상세 내용

* 비로그인일때는 기존처럼 전체 게시물을 최신순으로 페이징
* 로그인일때는 내가 팔로잉한사람들(나포함)의 게시물을 최신순으로 페이징
* 관련 슬라이싱 + 통합 테스트 작성

<br/>

## 기타

* 현재 인수테스트를 작성하지 못했습니다. 정확히는 홈피드에 대한 인수 테스트는 있는데, 여러 사람의 글을 조회하는 테스트 환경을 가진 테스트가 아닙니다. 이를 개선하려고 하는데요.
* 예전에 마크가 만들어둔 방법으로는 여러 명의 테스트 유저를 등록해두고 토큰을 가지고 환경을 조성할 수 있을 것 같습니다.
 
```java
        //마크 방식
    private ExtractableResponse<Response> 로그인_요청(User user) {
        // given
        String oauthCode = "1234";
        String accessToken = "oauth.access.token";

        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
            user.getName(), user.getImage(), user.getDescription(), user.getGithubUrl(),
            user.getCompany(), user.getLocation(), user.getWebsite(), user.getTwitter()
        );

        // mock
        when(oAuthClient.getAccessToken(oauthCode)).thenReturn(accessToken);
        when(oAuthClient.getGithubProfile(accessToken)).thenReturn(oAuthProfileResponse);

        // when
        return RestAssured
            .given().log().all()
            .accept(MediaType.APPLICATION_JSON_VALUE)
            .when()
            .get("/api/afterlogin?code=" + oauthCode)
            .then().log().all()
            .statusCode(HttpStatus.OK.value())
            .extract();
```

* 이렇게 마크 방식을 사용하면 서로 다른 유저별 토큰을 얻어올 수 있고, 이를 통해 게시글 작성 요청을 다양하게 보내서 여러 사람들의 게시물을 조회하는 테스트 환경 구축이 쉬워보입니다.
* 문제는 위와 같은 RestAssured 도배가 아니라 점진적으로 PickgitRequester 사용 전환으로 합의해서 저 또한 PickgitRequester를 사용함으로써 인수 테스트를 작성하려고 하는데요. 아래와 같은 어려움이 있습니다.
* MockGithubOauthClient 클래스가 OAuthProfileResponse를 단 1명의 유저 정보만 반환하고 있어서, 반환되는 JWT 토큰이 단 1명으로 고정되는 문제가 있습니다.

```java
    @Override
    public OAuthProfileResponse getGithubProfile(String githubAccessToken) {
        return new OAuthProfileResponse(
            "testUser",
            "https://github.com/testImage.jpg",
            "testDescription",
            "https://github.com/bperhaps",
            "testCompany",
            "testLocation",
            "testWebsite",
            "testTwitter"
        );
    }
```

* 이를 좀 개선할 필요가 있어보입니다...

<br/>

Close #355
