### PR TITLE
[#361] RestDocs에 이미지 파일 깨지는 버그 수정 및 누락 스니펫 추가

### DIFF
--- a/backend/pick-git/src/docs/asciidoc/comment.adoc
+++ b/backend/pick-git/src/docs/asciidoc/comment.adoc
@@ -19,9 +19,3 @@ include::{snippets}/comment-post/http-response.adoc[]
 include::{snippets}/comment-post-emptyContent/http-request.adoc[]
 ==== Response
 include::{snippets}/comment-post-emptyContent/http-response.adoc[]
-
-=== 댓글 등록 - 내용이 없는 경우
-==== Request
-include::{snippets}/comment-post-emptyContent/http-request.adoc[]
-==== Response
-include::{snippets}/comment-post-emptyContent/http-response.adoc[]

--- a/backend/pick-git/src/docs/asciidoc/index.adoc
+++ b/backend/pick-git/src/docs/asciidoc/index.adoc
@@ -13,5 +13,6 @@ include::following.adoc[]
 include::post.adoc[]
 include::profile.adoc[]
 include::tag.adoc[]
+include::search.adoc[]
 
 PickGit API

--- a/backend/pick-git/src/docs/asciidoc/post.adoc
+++ b/backend/pick-git/src/docs/asciidoc/post.adoc
@@ -20,20 +20,80 @@ include::{snippets}/posts-post-guest/http-request.adoc[]
 ==== Response
 include::{snippets}/posts-post-guest/http-response.adoc[]
 
-=== 홈 피드 요청 - 로그인
+=== 레포지토리 조회 - 로그인
+==== Request
+include::{snippets}/post-repositories-loggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-repositories-loggedIn/http-response.adoc[]
+
+=== 홈 피드 조회 요청 - 로그인
 ==== Request
 include::{snippets}/post-homefeed-LoggedIn/http-request.adoc[]
 ==== Response
 include::{snippets}/post-homefeed-LoggedIn/http-response.adoc[]
 
-=== 홈 피드 요청 - 비 로그인
+=== 홈 피드 조회 요청 - 비 로그인
 ==== Request
 include::{snippets}/post-homefeed-unLoggedIn/http-request.adoc[]
 ==== Response
 include::{snippets}/post-homefeed-unLoggedIn/http-response.adoc[]
 
-=== 레포지토리 요청 - 로그인
+=== 게시물 좋아요 - 로그인
 ==== Request
-include::{snippets}/repositories-loggedIn/http-request.adoc[]
+include::{snippets}/post-likePost-LoggedIn/http-request.adoc[]
 ==== Response
-include::{snippets}/repositories-loggedIn/http-response.adoc[]
+include::{snippets}/post-likePost-LoggedIn/http-response.adoc[]
+
+=== 게시물 좋아요 - 비 로그인
+==== Request
+include::{snippets}/post-likePost-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-likePost-unLoggedIn/http-response.adoc[]
+
+=== 게시물 좋아요 취소 - 로그인
+==== Request
+include::{snippets}/post-unlikePost-LoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-unlikePost-LoggedIn/http-response.adoc[]
+
+=== 게시물 좋아요 취소 - 비 로그인
+==== Request
+include::{snippets}/post-unlikePost-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-unlikePost-unLoggedIn/http-response.adoc[]
+
+=== 게시물 중복 좋아요
+==== Request
+include::{snippets}/post-likePost-duplicatedLike/http-request.adoc[]
+==== Response
+include::{snippets}/post-likePost-duplicatedLike/http-response.adoc[]
+
+=== 게시물 좋아하지 않은 게시물 좋아요 취소
+==== Request
+include::{snippets}/post-unlikePost-unlikedPost/http-request.adoc[]
+==== Response
+include::{snippets}/post-unlikePost-unlikedPost/http-response.adoc[]
+
+=== 게시물 수정
+==== Request
+include::{snippets}/post-update/http-request.adoc[]
+==== Response
+include::{snippets}/post-update/http-response.adoc[]
+
+=== 게시물 수정 - null 컨텐츠
+==== Request
+include::{snippets}/post-update-nullContent/http-request.adoc[]
+==== Response
+include::{snippets}/post-update-nullContent/http-response.adoc[]
+
+=== 게시물 수정 - 500자 이상 컨텐츠
+==== Request
+include::{snippets}/post-update-Over500Content/http-request.adoc[]
+==== Response
+include::{snippets}/post-update-Over500Content/http-response.adoc[]
+
+=== 게시물 삭제
+==== Request
+include::{snippets}/post-delete/http-request.adoc[]
+==== Response
+include::{snippets}/post-delete/http-response.adoc[]

--- a/backend/pick-git/src/docs/asciidoc/profile.adoc
+++ b/backend/pick-git/src/docs/asciidoc/profile.adoc
@@ -8,11 +8,17 @@ endif::[]
 :toclevels: 4
 
 == Profile
-=== 내 프로필 조회
+=== 내 프로필 조회 - 로그인
 ==== Request
-include::{snippets}/profilesMe/http-request.adoc[]
+include::{snippets}/profiles-me/http-request.adoc[]
 ==== Response
-include::{snippets}/profilesMe/http-response.adoc[]
+include::{snippets}/profiles-me/http-response.adoc[]
+
+=== 내 프로필 조회 - 비로그인
+==== Request
+include::{snippets}/profiles-me-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/profiles-me-unLoggedIn/http-response.adoc[]
 
 === 다른 사용자 프로필 조회 - 로그인
 ==== Request
@@ -25,3 +31,27 @@ include::{snippets}/profiles-LoggedIn/http-response.adoc[]
 include::{snippets}/profiles-unLoggedIn/http-request.adoc[]
 ==== Response
 include::{snippets}/profiles-unLoggedIn/http-response.adoc[]
+
+=== 내 프로필 수정 - 로그인
+==== Request
+include::{snippets}/profiles-edit/http-request.adoc[]
+==== Response
+include::{snippets}/profiles-edit/http-response.adoc[]
+
+=== 내 프로필 수정 - 비 로그인
+==== Request
+include::{snippets}/profiles-edit-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/profiles-edit-unLoggedIn/http-response.adoc[]
+
+=== Github 통계 조회 - 로그인
+==== Request
+include::{snippets}/profiles-contributions-LoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/profiles-contributions-LoggedIn/http-response.adoc[]
+
+=== Github 통계 조회 - 비 로그인
+==== Request
+include::{snippets}/profiles-contributions-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/profiles-contributions-unLoggedIn/http-response.adoc[]

--- a/backend/pick-git/src/docs/asciidoc/search.adoc
+++ b/backend/pick-git/src/docs/asciidoc/search.adoc
@@ -1,0 +1,21 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+
+== Search
+=== 유저 검색 - 로그인
+==== Request
+include::{snippets}/search-user-LoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-user-LoggedIn/http-response.adoc[]
+
+=== 유저 검색 - 비 로그인
+==== Request
+include::{snippets}/search-user-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/search-user-unLoggedIn/http-response.adoc[]

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.pickgit.authentication.application.OAuthService;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
-import com.woowacourse.pickgit.common.factory.FileFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.post.CannotUnlikeException;
 import com.woowacourse.pickgit.exception.post.CommentFormatException;
@@ -112,8 +111,8 @@ class PostControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(multipart("/api/posts")
-            .file(FileFactory.getTestImage1())
-            .file(FileFactory.getTestImage2())
+            .file("images", "testImage1".getBytes())
+            .file("images", "testImage2".getBytes())
             .param(PickGit.GITHUB_REPO_URL, "https://github.com/bperhaps")
             .param(PickGit.CONTENT, "content")
             .param(PickGit.TAGS, new String[]{"tag1", "tag2"})
@@ -145,8 +144,8 @@ class PostControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(multipart("/api/posts")
-            .file(FileFactory.getTestImage1())
-            .file(FileFactory.getTestImage2())
+            .file("images", "testImage1".getBytes())
+            .file("images", "testImage2".getBytes())
             .param(PickGit.GITHUB_REPO_URL, "https://github.com/bperhaps")
             .param(PickGit.CONTENT, "content")
             .param(PickGit.TAGS, new String[]{"tag1", "tag2"}));
@@ -305,7 +304,7 @@ class PostControllerTest {
             .andExpect(content().string(repositories));
 
         //documentation
-        perform.andDo(document("repositories-loggedIn",
+        perform.andDo(document("post-repositories-loggedIn",
             getDocumentRequest(),
             getDocumentResponse(),
             requestHeaders(

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/presentation/UserControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/presentation/UserControllerTest.java
@@ -114,7 +114,7 @@ class UserControllerTest {
             verify(userService, times(1))
                 .getMyUserProfile(any(AuthUserRequestDto.class));
 
-            perform.andDo(document("profilesMe",
+            perform.andDo(document("profiles-me",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(
@@ -327,7 +327,7 @@ class UserControllerTest {
 
             // when
             ResultActions perform = mockMvc.perform(multipart("/api/profiles/me")
-                .file(image)
+                .file("images", "testImage1".getBytes())
                 .param("description", description)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer token")
             );
@@ -344,7 +344,7 @@ class UserControllerTest {
                 .editProfile(any(AuthUserRequestDto.class), any(ProfileEditRequestDto.class));
 
             // restdocs
-            perform.andDo(document("edit-profile",
+            perform.andDo(document("profiles-edit",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(
@@ -396,7 +396,7 @@ class UserControllerTest {
             verify(userService, times(1))
                 .calculateContributions(any(ContributionRequestDto.class));
 
-            perform.andDo(document("contributions-LoggedIn",
+            perform.andDo(document("profiles-contributions-LoggedIn",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(
@@ -441,7 +441,7 @@ class UserControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("errorCode").value("A0001"));
 
-            perform.andDo(document("profilesMe",
+            perform.andDo(document("profiles-me-unLoggedIn",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(
@@ -577,15 +577,13 @@ class UserControllerTest {
         @Test
         void editUserProfile_GuestUser_Fail() throws Exception {
             // given
-            MockMultipartFile image = FileFactory.getTestImage1();
-
             // mock
             given(oAuthService.validateToken(any()))
                 .willReturn(false);
 
             // when
             ResultActions perform = mockMvc.perform(multipart("/api/profiles/me")
-                .file(image)
+                .file("images", "testImage1".getBytes())
                 .param("description", "updated description")
             );
 
@@ -595,6 +593,15 @@ class UserControllerTest {
                 .andExpect(jsonPath("errorCode").value("A0001"));
 
             verify(oAuthService, times(1)).validateToken(any());
+
+            perform.andDo(document("profiles-edit-unLoggedIn",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestPartBody("images"),
+                responseFields(
+                    fieldWithPath("errorCode").type(STRING).description("에러 코드")
+                )
+            ));
         }
 
         @DisplayName("게스트는 활동 통계를 조회할 수 없다. - 401 예외")
@@ -625,7 +632,7 @@ class UserControllerTest {
             verify(oAuthService, times(1))
                 .findRequestUserByToken(null);
 
-            perform.andDo(document("contribution-unLoggedIn",
+            perform.andDo(document("profiles-contributions-unLoggedIn",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(


### PR DESCRIPTION
## 상세 내용
- multipart 전송 시 File을 restDocs에 인자로 기록할 때 깨지는 버그를 해결
- 테스트에는 작성이 되어 있으나 restDocs 스니펫 추가가 누락된 것들을 추가
<br/>

## 기타
- 프로필 수정 관련 restDocs 테스트 코드가 누락되어 추가 
- 스니펫 이름 통일성 있도록 수정

<br/>

Close #361 
