### PR TITLE
[#372] spring rest docs html 생성 버그 해결

### DIFF
--- a/backend/pick-git/build.gradle
+++ b/backend/pick-git/build.gradle
@@ -62,15 +62,15 @@ asciidoctor {
 	dependsOn test
 }
 
-task copyDocuments(type: Copy) {
+bootJar {
 	dependsOn asciidoctor
 
-	from file("build/asciidoc/html5/index.html")
-	into file("src/main/resources/static/docs")
-}
+	copy {
+		from 'build/asciidoc/html5'
+		into 'src/main/resources/static/docs'
+		include '*.html'
+	}
 
-bootJar {
-	dependsOn copyDocuments
 }
 
 test {


### PR DESCRIPTION
## 상세 내용

문서 생성 에러를 해결합니다.

그루비 문법의 미성숙함으로 인한 버그로 판단됩니다.
dependsOn 을 하면 무조건 적으로 의존하는 부분을 먼저 실행한다고 생각했는데(실제로 그러기도 하고)
파일 복사 부분의 경우는 그렇지 않나 봅니다. 

생성된 html파일을 자르 파일 안으로 옮기지 못하는 버그가 있었습니다.
추측함에 따르면, 빌드 후에(자르파일 생성 후에) 파일 복사가 이루어지는 것 같은데, 소스상으로는 의존성을 먹여두었기 때문에 먼저 파일이 만들어졌어야 하는데... 이유는 잘 모르겠습니다. 디버거로 타고 들어가 봐도, IDE의 EIP가 읽는 부분과 실제 실행부가 다르다고 느껴집니다.

파일 복사 스크립트를 bootJar쪽으로 옮겨 해결하였습니다.

<br/>

## 기타

관련된 논의 사항으로, 현재 빌드시 테스트와 레스트 독스를 모두 시행하도록 되어 있는데, 빌드와 레스트 독스 실행 시점을 분리하여 파이프 라인을 조금 더 세밀화 시킬 수 있다고 생각하는데 동의 하시나요?

### 기존
체크아웃 -> 테스트, 레독생성, 빌드 -> 배포

### 변경
체크아우 -> 빌드(소스코드의 무결함 확인) -> 테스트 -> 레독생성과 빌드(자르 안에 도큐먼트 주입) -> 배포


<br/>

Close #372