### PR TITLE
[#374] 좋아요 리스트 조회 기능 구현 

### DIFF
--- a/backend/pick-git/src/docs/asciidoc/post.adoc
+++ b/backend/pick-git/src/docs/asciidoc/post.adoc
@@ -74,6 +74,24 @@ include::{snippets}/post-unlikePost-unlikedPost/http-request.adoc[]
 ==== Response
 include::{snippets}/post-unlikePost-unlikedPost/http-response.adoc[]
 
+=== 게시물 좋아요 리스트 조회 - 로그인
+==== Request
+include::{snippets}/post-likeUsers-loggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-likeUsers-loggedIn/http-response.adoc[]
+
+=== 게시물 좋아요 리스트 조회 - 비 로그인
+==== Request
+include::{snippets}/post-likeUsers-unLoggedIn/http-request.adoc[]
+==== Response
+include::{snippets}/post-likeUsers-unLoggedIn/http-response.adoc[]
+
+=== 좋아요 없는 게시물 조회 - 비 로그인
+==== Request
+include::{snippets}/post-likeUsers-emptyLikes/http-request.adoc[]
+==== Response
+include::{snippets}/post-likeUsers-emptyLikes/http-response.adoc[]
+
 === 게시물 수정
 ==== Request
 include::{snippets}/post-update/http-request.adoc[]

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -68,6 +68,7 @@ public class OAuthConfiguration implements WebMvcConfigurer {
             .addPathPatterns("/api/search/**", HttpMethod.GET)
             .addPathPatterns("/api/profiles/*/followings", HttpMethod.GET)
             .addPathPatterns("/api/profiles/*/followers", HttpMethod.GET)
+            .addPathPatterns("/api/posts/*/likes", HttpMethod.GET)
             .excludePatterns("/api/profiles/*/followings", HttpMethod.POST, HttpMethod.DELETE)
             .excludePatterns("/api/profiles/me", HttpMethod.GET)
             .excludePatterns("/api/posts/me", HttpMethod.GET)

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
@@ -100,56 +100,6 @@ public class PostFeedService {
         return PostDtoAssembler.assembleFrom(user, isGuest, search);
     }
 
-    @Transactional(readOnly = true)
-    public List<LikeUsersResponseDto> likeUsers(
-        AuthUserForPostRequestDto authUserRequestDto, Long postId
-    ) {
-        Post post = findPostWithLikeUsers(postId);
-        List<User> likeUsers = post.getLikeUsers();
-
-        if (authUserRequestDto.isGuest()) {
-            return createLikeUsersResponseDtoOfGuest(likeUsers);
-        }
-
-        User loginUser = findUserByName(authUserRequestDto.getUsername());
-        List<LikeUsersResponseDto> likeUsersResponseDtoOfLoginUser =
-            createLikeUsersResponseDtoOfLoginUser(loginUser, likeUsers);
-
-        return likeUsersResponseDtoOfLoginUser;
-    }
-
-    private Post findPostWithLikeUsers(Long postId) {
-        return postRepository.findPostWithLikeUsers(postId)
-            .orElseThrow(PostNotFoundException::new);
-    }
-
-    private List<LikeUsersResponseDto> createLikeUsersResponseDtoOfGuest(
-        List<User> likeUsers
-    ) {
-        return likeUsers.stream()
-            .map(user ->
-                new LikeUsersResponseDto(
-                    user.getImage(),
-                    user.getName(),
-                    null
-                )
-            ).collect(toList());
-    }
-
-    private List<LikeUsersResponseDto> createLikeUsersResponseDtoOfLoginUser(
-        User loginUser,
-        List<User> likeUsers
-    ) {
-        return likeUsers.stream()
-            .map(user ->
-                new LikeUsersResponseDto(
-                    user.getImage(),
-                    user.getName(),
-                    loginUser.isFollowing(user)
-                )
-            ).collect(toList());
-    }
-
     private User findUserByName(String userName) {
         if(Objects.isNull(userName)) {
             return null;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostFeedService.java
@@ -101,7 +101,9 @@ public class PostFeedService {
     }
 
     @Transactional(readOnly = true)
-    public List<LikeUsersResponseDto> likeUsers(AuthUserForPostRequestDto authUserRequestDto, Long postId) {
+    public List<LikeUsersResponseDto> likeUsers(
+        AuthUserForPostRequestDto authUserRequestDto, Long postId
+    ) {
         Post post = findPostWithLikeUsers(postId);
         List<User> likeUsers = post.getLikeUsers();
 
@@ -110,8 +112,9 @@ public class PostFeedService {
         }
 
         User loginUser = findUserByName(authUserRequestDto.getUsername());
-        List<LikeUsersResponseDto> likeUsersResponseDtoOfLoginUser = createLikeUsersResponseDtoOfLoginUser(
-            loginUser, likeUsers);
+        List<LikeUsersResponseDto> likeUsersResponseDtoOfLoginUser =
+            createLikeUsersResponseDtoOfLoginUser(loginUser, likeUsers);
+
         return likeUsersResponseDtoOfLoginUser;
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/AuthUserForPostRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/AuthUserForPostRequestDto.java
@@ -1,0 +1,29 @@
+package com.woowacourse.pickgit.post.application.dto.request;
+
+import com.woowacourse.pickgit.authentication.domain.user.AppUser;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AuthUserForPostRequestDto {
+
+    private String username;
+    private boolean isGuest;
+
+    private AuthUserForPostRequestDto() {
+    }
+
+    public AuthUserForPostRequestDto(String username, boolean isGuest) {
+        this.username = username;
+        this.isGuest = isGuest;
+    }
+
+    public static AuthUserForPostRequestDto from(AppUser appUser) {
+        if (appUser.isGuest()) {
+            return new AuthUserForPostRequestDto(null, true);
+        }
+        return new AuthUserForPostRequestDto(appUser.getUsername(), false);
+    }
+}
+

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/AuthUserForPostRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/request/AuthUserForPostRequestDto.java
@@ -18,12 +18,5 @@ public class AuthUserForPostRequestDto {
         this.username = username;
         this.isGuest = isGuest;
     }
-
-    public static AuthUserForPostRequestDto from(AppUser appUser) {
-        if (appUser.isGuest()) {
-            return new AuthUserForPostRequestDto(null, true);
-        }
-        return new AuthUserForPostRequestDto(appUser.getUsername(), false);
-    }
 }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/response/LikeUsersResponseDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/dto/response/LikeUsersResponseDto.java
@@ -1,0 +1,30 @@
+package com.woowacourse.pickgit.post.application.dto.response;
+
+public class LikeUsersResponseDto {
+
+    private String imageUrl;
+    private String username;
+    private Boolean following;
+
+    private LikeUsersResponseDto() {
+    }
+
+    public LikeUsersResponseDto(String imageUrl, String username, Boolean following) {
+        this.imageUrl = imageUrl;
+        this.username = username;
+        this.following = following;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Boolean getFollowing() {
+        return following;
+    }
+
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
@@ -63,7 +63,7 @@ public class Post {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    private Post() {
+    protected Post() {
     }
 
     public Post(

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/Post.java
@@ -63,10 +63,10 @@ public class Post {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    protected Post() {
+    private Post() {
     }
 
-    protected Post(
+    public Post(
         Long id,
         User user,
         Images images,
@@ -174,6 +174,14 @@ public class Post {
 
     public List<String> getTagNames() {
         return postTags.getTagNames();
+    }
+
+    public Likes getLikes() {
+        return likes;
+    }
+
+    public List<User> getLikeUsers() {
+        return likes.getLikeUsers();
     }
 
     @Override

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/like/Like.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/like/Like.java
@@ -44,7 +44,7 @@ public class Like {
         return post;
     }
 
-    private User getUser() {
+    public User getUser() {
         return user;
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/like/Likes.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/like/Likes.java
@@ -1,9 +1,13 @@
 package com.woowacourse.pickgit.post.domain.like;
 
+import static java.util.stream.Collectors.toList;
+
 import com.woowacourse.pickgit.exception.post.CannotUnlikeException;
 import com.woowacourse.pickgit.exception.post.DuplicatedLikeException;
+import com.woowacourse.pickgit.user.domain.User;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
@@ -49,5 +53,15 @@ public class Likes {
             throw new CannotUnlikeException();
         }
         likes.remove(like);
+    }
+
+    public List<User> getLikeUsers() {
+        return likes.stream()
+            .map(Like::getUser)
+            .collect(toList());
+    }
+
+    public List<Like> getLikes() {
+        return likes;
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PostRepository.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/domain/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.woowacourse.pickgit.post.domain.repository;
 import com.woowacourse.pickgit.post.domain.Post;
 import com.woowacourse.pickgit.user.domain.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("select distinct p from PostTag pt inner join pt.post p where pt.tag.name in :tagName")
     List<Post> findAllPostsByTagNames(@Param("tagName") List<String> tagName, Pageable pageable);
+
+    @Query("select distinct p from Post p left join fetch p.likes.likes l left join fetch l.user where p.id = :postId")
+    Optional<Post> findPostWithLikeUsers(@Param("postId") Long postId);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
@@ -236,12 +236,20 @@ public class PostController {
         @Authenticated AppUser appUser,
         @PathVariable Long postId
     ) {
-        AuthUserForPostRequestDto authUserRequestDto = AuthUserForPostRequestDto.from(appUser);
+        AuthUserForPostRequestDto authUserRequestDto = createAuthUserForPostRequestDto(appUser);
 
         List<LikeUsersResponseDto> likeUsersResponseDtos = postService
             .likeUsers(authUserRequestDto, postId);
 
         return ResponseEntity.ok(createLikeUsersResponse(likeUsersResponseDtos));
+    }
+
+    private AuthUserForPostRequestDto createAuthUserForPostRequestDto(AppUser appUser) {
+         if (appUser.isGuest()) {
+             return new AuthUserForPostRequestDto(null, true);
+         }
+
+         return new AuthUserForPostRequestDto(appUser.getUsername(), false);
     }
 
     private List<LikeUsersResponse> createLikeUsersResponse(

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostController.java
@@ -6,12 +6,14 @@ import com.woowacourse.pickgit.authentication.domain.Authenticated;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.exception.authentication.UnauthorizedException;
 import com.woowacourse.pickgit.post.application.PostService;
+import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostDeleteRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.PostUpdateRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.RepositoryRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.SearchRepositoryRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeResponseDto;
+import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostImageUrlResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostUpdateResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.RepositoryResponseDto;
@@ -19,6 +21,7 @@ import com.woowacourse.pickgit.post.application.dto.response.RepositoryResponses
 import com.woowacourse.pickgit.post.presentation.dto.request.PostRequest;
 import com.woowacourse.pickgit.post.presentation.dto.request.PostUpdateRequest;
 import com.woowacourse.pickgit.post.presentation.dto.response.LikeResponse;
+import com.woowacourse.pickgit.post.presentation.dto.response.LikeUsersResponse;
 import com.woowacourse.pickgit.post.presentation.dto.response.PostUpdateResponse;
 import com.woowacourse.pickgit.post.presentation.dto.response.RepositoryResponse;
 import java.net.URI;
@@ -226,5 +229,29 @@ public class PostController {
 
     private PostDeleteRequestDto createPostDeleteRequestDto(AppUser user, Long postId) {
         return new PostDeleteRequestDto(user, postId);
+    }
+
+    @GetMapping("/posts/{postId}/likes")
+    public ResponseEntity<List<LikeUsersResponse>> searchLikeUsers(
+        @Authenticated AppUser appUser,
+        @PathVariable Long postId
+    ) {
+        AuthUserForPostRequestDto authUserRequestDto = AuthUserForPostRequestDto.from(appUser);
+
+        List<LikeUsersResponseDto> likeUsersResponseDtos = postService
+            .likeUsers(authUserRequestDto, postId);
+
+        return ResponseEntity.ok(createLikeUsersResponse(likeUsersResponseDtos));
+    }
+
+    private List<LikeUsersResponse> createLikeUsersResponse(
+        List<LikeUsersResponseDto> likeUsersResponseDtos) {
+        return likeUsersResponseDtos.stream()
+            .map(dto -> LikeUsersResponse.builder()
+                .username(dto.getUsername())
+                .imageUrl(dto.getImageUrl())
+                .following(dto.getFollowing())
+                .build()
+            ).collect(toList());
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostFeedController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostFeedController.java
@@ -5,10 +5,13 @@ import static java.util.stream.Collectors.toList;
 import com.woowacourse.pickgit.authentication.domain.Authenticated;
 import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.HomeFeedRequestDto;
 import com.woowacourse.pickgit.post.application.dto.request.SearchPostsRequestDto;
+import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
 import com.woowacourse.pickgit.post.presentation.dto.request.SearchPostsRequest;
+import com.woowacourse.pickgit.post.presentation.dto.response.LikeUsersResponse;
 import com.woowacourse.pickgit.post.presentation.dto.response.PostResponse;
 import java.util.List;
 import java.util.function.Function;
@@ -112,5 +115,29 @@ public class PostFeedController {
             .comments(postResponseDto.getComments())
             .liked(postResponseDto.getLiked())
             .build();
+    }
+
+    @GetMapping("/posts/{postId}/likes")
+    public ResponseEntity<List<LikeUsersResponse>> searchLikeUsers(
+        @Authenticated AppUser appUser,
+        @PathVariable Long postId
+    ) {
+        AuthUserForPostRequestDto authUserRequestDto = AuthUserForPostRequestDto.from(appUser);
+
+        List<LikeUsersResponseDto> likeUsersResponseDtos = postFeedService
+            .likeUsers(authUserRequestDto, postId);
+
+        return ResponseEntity.ok(createLikeUsersResponse(likeUsersResponseDtos));
+    }
+
+    private List<LikeUsersResponse> createLikeUsersResponse(
+        List<LikeUsersResponseDto> likeUsersResponseDtos) {
+        return likeUsersResponseDtos.stream()
+            .map(dto -> LikeUsersResponse.builder()
+                .username(dto.getUsername())
+                .imageUrl(dto.getImageUrl())
+                .following(dto.getFollowing())
+                .build()
+            ).collect(toList());
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostFeedController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/PostFeedController.java
@@ -116,28 +116,4 @@ public class PostFeedController {
             .liked(postResponseDto.getLiked())
             .build();
     }
-
-    @GetMapping("/posts/{postId}/likes")
-    public ResponseEntity<List<LikeUsersResponse>> searchLikeUsers(
-        @Authenticated AppUser appUser,
-        @PathVariable Long postId
-    ) {
-        AuthUserForPostRequestDto authUserRequestDto = AuthUserForPostRequestDto.from(appUser);
-
-        List<LikeUsersResponseDto> likeUsersResponseDtos = postFeedService
-            .likeUsers(authUserRequestDto, postId);
-
-        return ResponseEntity.ok(createLikeUsersResponse(likeUsersResponseDtos));
-    }
-
-    private List<LikeUsersResponse> createLikeUsersResponse(
-        List<LikeUsersResponseDto> likeUsersResponseDtos) {
-        return likeUsersResponseDtos.stream()
-            .map(dto -> LikeUsersResponse.builder()
-                .username(dto.getUsername())
-                .imageUrl(dto.getImageUrl())
-                .following(dto.getFollowing())
-                .build()
-            ).collect(toList());
-    }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/response/LikeUsersResponse.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/presentation/dto/response/LikeUsersResponse.java
@@ -1,0 +1,32 @@
+package com.woowacourse.pickgit.post.presentation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class LikeUsersResponse {
+
+    private String imageUrl;
+    private String username;
+    private Boolean following;
+
+    private LikeUsersResponse() {
+    }
+
+    public LikeUsersResponse(String imageUrl, String username, Boolean following) {
+        this.imageUrl = imageUrl;
+        this.username = username;
+        this.following = following;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Boolean getFollowing() {
+        return following;
+    }
+}

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/AuthUserForUserRequestDto.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/application/dto/request/AuthUserForUserRequestDto.java
@@ -29,6 +29,10 @@ public class AuthUserForUserRequestDto {
         if (appUser.isGuest()) {
             return new AuthUserForUserRequestDto(null, true);
         }
-        return new AuthUserForUserRequestDto(appUser.getUsername(), appUser.getAccessToken(), false);
+        return new AuthUserForUserRequestDto(
+            appUser.getUsername(),
+            appUser.getAccessToken(),
+            false
+        );
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/domain/User.java
@@ -92,6 +92,10 @@ public class User {
     }
 
     public Boolean isFollowing(User targetUser) {
+        if (this.equals(targetUser)) {
+            return null;
+        }
+
         return this.followings.isFollowing(targetUser);
     }
 

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/presentation/UserController.java
@@ -104,6 +104,7 @@ public class UserController {
             .targetName(username)
             .githubFollowing(githubFollowing)
             .build();
+
         FollowResponseDto followResponseDto =
             userService.followUser(followRequestDto);
 
@@ -121,6 +122,7 @@ public class UserController {
             .targetName(username)
             .githubFollowing(githubUnfollowing)
             .build();
+
         FollowResponseDto followResponseDto =
             userService.unfollowUser(unfollowRequestDto);
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
@@ -91,9 +91,12 @@ public class PostAcceptanceTest_LikeUsers {
             .map(user -> {
                     if (isFollowingUser(likeUsers, user)) {
                         return new LikeUsersResponse(user.getImage(), user.getName(), true);
-                    } else if (user.getName().equals("author")) {
+                    }
+
+                    if (user.getName().equals("author")) {
                         return new LikeUsersResponse(user.getImage(), user.getName(), null);
                     }
+
                     return new LikeUsersResponse(user.getImage(), user.getName(), false);
                 }
             ).collect(toList());

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
@@ -213,7 +213,7 @@ public class PostAcceptanceTest_LikeUsers {
         RestAssured.given().log().all()
             .auth().oauth2(token)
             .when()
-            .post("/api/profiles/{targetUserName}/followings", targetUserName)
+            .post("/api/profiles/{targetUserName}/followings?githubFollowing=false", targetUserName)
             .then().log().all()
             .statusCode(HttpStatus.OK.value());
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
@@ -1,9 +1,7 @@
 package com.woowacourse.pickgit.acceptance.post;
 
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
@@ -99,6 +97,11 @@ public class PostAcceptanceTest_LikeUsers {
                     return new LikeUsersResponse(user.getImage(), user.getName(), false);
                 }
             ).collect(toList());
+    }
+
+    private boolean isFollowingUser(List<User> likeUsers, User user) {
+        return user.getName().equals(likeUsers.get(0).getName())
+            || user.getName().equals(likeUsers.get(1).getName());
     }
 
     @DisplayName("특정 게시물을 좋아요한 계정 리스트를 조회할 수 있다 - 비 로그인/성공")
@@ -213,11 +216,6 @@ public class PostAcceptanceTest_LikeUsers {
             .post("/api/profiles/{targetUserName}/followings", targetUserName)
             .then().log().all()
             .statusCode(HttpStatus.OK.value());
-    }
-
-    private boolean isFollowingUser(List<User> likeUsers, User user) {
-        return user.getName().equals(likeUsers.get(0).getName())
-            || user.getName().equals(likeUsers.get(1).getName());
     }
 
     @DisplayName("존재하지 않은 포스트를 조회하면 500예외가 발생한다. - 비 로그인/실")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
@@ -1,0 +1,283 @@
+package com.woowacourse.pickgit.acceptance.post;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.pickgit.authentication.application.dto.OAuthProfileResponse;
+import com.woowacourse.pickgit.authentication.domain.OAuthClient;
+import com.woowacourse.pickgit.authentication.presentation.dto.OAuthTokenResponse;
+import com.woowacourse.pickgit.common.factory.FileFactory;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
+import com.woowacourse.pickgit.exception.post.PostNotFoundException;
+import com.woowacourse.pickgit.post.presentation.dto.response.LikeUsersResponse;
+import com.woowacourse.pickgit.user.domain.User;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(InfrastructureTestConfiguration.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+public class PostAcceptanceTest_LikeUsers {
+
+    @LocalServerPort
+    private int port;
+
+    @MockBean
+    private OAuthClient oAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("특정 게시물을 좋아요한 계정 리스트를 조회할 수 있다 - 로그인/성공")
+    @Test
+    void searchLikeUsers_LoginUser_Success() {
+        // given
+        Long postId = 1L;
+        String authorToken = 로그인_되어있음("author").getToken();
+        List<User> likeUsers = UserFactory.mockLikeUsersIncludingAuthor();
+
+        writePost(authorToken);
+        likePosts(postId, likeUsers);
+        followSomeUsers(authorToken, likeUsers);
+
+        List<LikeUsersResponse> expectedResponse = createLikeUserResponseForLoginUser(likeUsers);
+
+        // when
+        List<LikeUsersResponse> actualResponse =
+            requestLikeUsersForLoginUser(authorToken, postId)
+                .as(new TypeRef<>() {});
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+    }
+
+    private ExtractableResponse<Response> requestLikeUsersForLoginUser(String token, Long postId) {
+        return RestAssured.given().log().all()
+            .auth().oauth2(token)
+            .when()
+            .get("/api/posts/{postId}/likes", postId)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+    }
+
+    private List<LikeUsersResponse> createLikeUserResponseForLoginUser(List<User> likeUsers) {
+        return likeUsers.stream()
+            .map(user -> {
+                    if (isFollowingUser(likeUsers, user)) {
+                        return new LikeUsersResponse(user.getImage(), user.getName(), true);
+                    } else if (user.getName().equals("author")) {
+                        return new LikeUsersResponse(user.getImage(), user.getName(), null);
+                    }
+                    return new LikeUsersResponse(user.getImage(), user.getName(), false);
+                }
+            ).collect(toList());
+    }
+
+    @DisplayName("특정 게시물을 좋아요한 계정 리스트를 조회할 수 있다 - 비 로그인/성공")
+    @Test
+    void searchLikeUsers_GuestUser_Success() {
+        // given
+        Long postId = 1L;
+        String authorToken = 로그인_되어있음("author").getToken();
+        List<User> likeUsers = UserFactory.mockLikeUsersIncludingAuthor();
+
+        writePost(authorToken);
+        likePosts(postId, likeUsers);
+
+        List<LikeUsersResponse> expectedResponse = createLikeUserResponseForGuest(likeUsers);
+
+        // when
+        List<LikeUsersResponse> actualResponse =
+            requestLikeUsersForGuest(postId)
+                .as(new TypeRef<>() {});
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+    }
+
+    private List<LikeUsersResponse> createLikeUserResponseForGuest(List<User> likeUsers) {
+        return likeUsers.stream()
+            .map(
+                user -> new LikeUsersResponse(user.getImage(), user.getName(), null)
+            ).collect(toList());
+    }
+
+    @DisplayName("좋아요가 없는 게시물을 조회하면 빈 배열을 반환한다. - 비 로그인/성공")
+    @Test
+    void searchLikeUsers_EmptyLikes_Success() {
+        // given
+        Long postId = 1L;
+        String authorToken = 로그인_되어있음("author").getToken();
+
+        writePost(authorToken);
+
+        // when
+        List<LikeUsersResponse> actualResponse =
+            requestLikeUsersForGuest(postId)
+                .as(new TypeRef<>() {});
+
+        // then
+        assertThat(actualResponse).isEmpty();
+    }
+
+    private ExtractableResponse<Response> requestLikeUsersForGuest(Long postId) {
+        return RestAssured.given().log().all()
+            .when()
+            .get("/api/posts/{postId}/likes", postId)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+    }
+
+    private void writePost(String token) {
+        Map<String, Object> request = new HashMap<>();
+        request.put("githubRepoUrl", "https://github.com/woowacourse-teams/2021-pick-git");
+        request.put("tags", List.of("java", "spring"));
+        request.put("content", "this is content");
+
+        RestAssured.given().log().all()
+            .auth().oauth2(token)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .formParams(request)
+            .multiPart("images", FileFactory.getTestImage1File())
+            .multiPart("images", FileFactory.getTestImage2File())
+            .when()
+            .post("/api/posts")
+            .then().log().all()
+            .statusCode(HttpStatus.CREATED.value());
+    }
+
+    private void likePosts(Long postId, List<User> likeUsers) {
+        likeUsers.forEach(
+            user -> {
+                String token = 로그인_되어있음(user.getName()).getToken();
+                likePost(token, postId);
+            }
+        );
+    }
+
+    private void likePost(String token, Long postId) {
+        RestAssured.given().log().all()
+            .auth().oauth2(token)
+            .when()
+            .put("/api/posts/{postId}/likes", postId)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    private void followSomeUsers(String authorToken, List<User> likeUsers) {
+        for (int i = 0; i < 2; i++) {
+            followUser(
+                authorToken,
+                likeUsers
+                    .get(i)
+                    .getName()
+            );
+        }
+    }
+
+    private void followUser(String token, String targetUserName) {
+        RestAssured.given().log().all()
+            .auth().oauth2(token)
+            .when()
+            .post("/api/profiles/{targetUserName}/followings", targetUserName)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    private boolean isFollowingUser(List<User> likeUsers, User user) {
+        return user.getName().equals(likeUsers.get(0).getName())
+            || user.getName().equals(likeUsers.get(1).getName());
+    }
+
+    @DisplayName("존재하지 않은 포스트를 조회하면 500예외가 발생한다. - 비 로그인/실")
+    @Test
+    void searchLikeUsers_InvalidPostId_500Exception() {
+        // given
+        Long postId = 1L;
+
+        // when
+        PostNotFoundException response =
+            requestInvalidPostLikeUsersForGuest(postId)
+                .as(PostNotFoundException.class);
+
+        // then
+        assertThat(response)
+            .isInstanceOf(PostNotFoundException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "P0002")
+            .hasFieldOrPropertyWithValue("message", "해당하는 게시물을 찾을 수 없습니다.");
+    }
+
+    private ExtractableResponse<Response> requestInvalidPostLikeUsersForGuest(Long postId) {
+        return RestAssured.given().log().all()
+            .when()
+            .get("/api/posts/{postId}/likes", postId)
+            .then().log().all()
+            .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .extract();
+    }
+
+    private OAuthTokenResponse 로그인_되어있음(String name) {
+        OAuthTokenResponse response = 로그인_요청(name)
+            .as(OAuthTokenResponse.class);
+
+        assertThat(response.getToken()).isNotBlank();
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 로그인_요청(String name) {
+        // given
+        String oauthCode = "1234";
+        String accessToken = "oauth.access.token";
+
+        OAuthProfileResponse oAuthProfileResponse = new OAuthProfileResponse(
+            name, "http://img.com", "hi~", "github.com/",
+            null, null, null, null
+        );
+
+        given(oAuthClient.getAccessToken(oauthCode))
+            .willReturn(accessToken);
+        given(oAuthClient.getGithubProfile(accessToken))
+            .willReturn(oAuthProfileResponse);
+
+        // when
+        return RestAssured.given().log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/afterlogin?code=" + oauthCode)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/post/PostAcceptanceTest_LikeUsers.java
@@ -218,7 +218,7 @@ public class PostAcceptanceTest_LikeUsers {
             .statusCode(HttpStatus.OK.value());
     }
 
-    @DisplayName("존재하지 않은 포스트를 조회하면 500예외가 발생한다. - 비 로그인/실")
+    @DisplayName("존재하지 않은 포스트를 조회하면 500예외가 발생한다. - 비 로그인/실패")
     @Test
     void searchLikeUsers_InvalidPostId_500Exception() {
         // given

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
@@ -211,6 +211,7 @@ class UserAcceptance_GetFollowingsAndFollowers {
         for (User user : usersInDb) {
             AuthUserForUserRequestDto mockUserAuthDto =
                 AuthUserForUserRequestDto.from(new LoginUser(user.getName(), "token"));
+
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(mockUserAuthDto)
                 .targetName(target.getName())

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/MockPost.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/MockPost.java
@@ -1,0 +1,112 @@
+package com.woowacourse.pickgit.common.factory;
+
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.comment.Comments;
+import com.woowacourse.pickgit.post.domain.content.Image;
+import com.woowacourse.pickgit.post.domain.content.Images;
+import com.woowacourse.pickgit.post.domain.content.PostContent;
+import com.woowacourse.pickgit.post.domain.like.Likes;
+import com.woowacourse.pickgit.post.domain.tag.PostTags;
+import com.woowacourse.pickgit.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MockPost {
+
+    private MockPost() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Long id;
+        private User user;
+        private Images images =
+            new Images(
+                List.of(new Image("www.image1.com"), new Image("www.image2.com"))
+            );
+        private PostContent content =
+            new PostContent("Post content");
+        private Likes likes =
+            new Likes();
+        private Comments comments =
+            new Comments();
+        private PostTags postTags =
+            new PostTags();
+        private String githubRepoUrl =
+            "www.github.com/pick-git";
+        private LocalDateTime createdAt =
+            LocalDateTime.of(2000, 2, 2, 2, 2);
+        private LocalDateTime updatedAt =
+            LocalDateTime.of(2000, 2, 2, 2, 2);
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder user(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder images(Images images) {
+            this.images = images;
+            return this;
+        }
+
+        public Builder postContents(PostContent postContent) {
+            this.content = postContent;
+            return this;
+        }
+
+        public Builder likes(Likes likes) {
+            this.likes = likes;
+            return this;
+        }
+
+        public Builder comments(Comments comments) {
+            this.comments = comments;
+            return this;
+        }
+
+        public Builder postTags(PostTags postTags) {
+            this.postTags = postTags;
+            return this;
+        }
+
+        public Builder githubRepoUrl(String githubRepoUrl) {
+            this.githubRepoUrl = githubRepoUrl;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder updatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        public Post build() {
+            return new Post(
+                id,
+                user,
+                images,
+                content,
+                likes,
+                comments,
+                postTags,
+                githubRepoUrl,
+                createdAt,
+                updatedAt
+            );
+        }
+    }
+
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/MockPost.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/MockPost.java
@@ -1,7 +1,7 @@
 package com.woowacourse.pickgit.common.factory;
 
+import com.woowacourse.pickgit.comment.domain.Comments;
 import com.woowacourse.pickgit.post.domain.Post;
-import com.woowacourse.pickgit.post.domain.comment.Comments;
 import com.woowacourse.pickgit.post.domain.content.Image;
 import com.woowacourse.pickgit.post.domain.content.Images;
 import com.woowacourse.pickgit.post.domain.content.PostContent;

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/PostFactory.java
@@ -3,8 +3,12 @@ package com.woowacourse.pickgit.common.factory;
 import com.woowacourse.pickgit.post.application.dto.request.PostRequestDto;
 import com.woowacourse.pickgit.comment.application.dto.response.CommentResponseDto;
 import com.woowacourse.pickgit.post.application.dto.response.PostResponseDto;
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.like.Likes;
+import com.woowacourse.pickgit.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.mockito.Mock;
 import org.springframework.web.multipart.MultipartFile;
 
 public class PostFactory {
@@ -153,5 +157,23 @@ public class PostFactory {
             .build();
 
         return List.of(fixture1);
+    }
+
+    public static Post post() {
+        return MockPost.builder()
+            .build();
+    }
+
+    public static Post post(User author) {
+        return MockPost.builder()
+            .user(author)
+            .build();
+    }
+
+    public static Post likedPost(User author, Likes likes) {
+        return MockPost.builder()
+            .user(author)
+            .likes(likes)
+            .build();
     }
 }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/UserFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/UserFactory.java
@@ -27,6 +27,7 @@ public class UserFactory {
         return createUser(id, name, imageUrl);
     }
 
+
     public static User user() {
         return createUser(null, "testUser");
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/UserFactory.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/factory/UserFactory.java
@@ -11,12 +11,20 @@ public class UserFactory {
     private UserFactory() {
     }
 
+    public static User user(String name) {
+        return createUser(null, name);
+    }
+
     public static User user(Long id, String name) {
         return createUser(id, name);
     }
 
-    public static User user(String name) {
-        return createUser(null, name);
+    public static User user(String name, String imageUrl) {
+        return createUser(null, name, imageUrl);
+    }
+
+    public static User user(Long id, String name, String imageUrl) {
+        return createUser(id, name, imageUrl);
     }
 
     public static User user() {
@@ -27,6 +35,14 @@ public class UserFactory {
         return MockUser.builder()
             .id(id)
             .name(name)
+            .build();
+    }
+
+    public static User createUser(Long id, String name, String imageUrl) {
+        return MockUser.builder()
+            .id(id)
+            .name(name)
+            .image(imageUrl)
             .build();
     }
 
@@ -116,11 +132,11 @@ public class UserFactory {
     }
 
     public static List<User> mockSearchUsers() {
-        User user1 = user( "binghe");
-        User user2 = user( "bing");
-        User user3 = user( "jinbinghe");
-        User user4 = user( "bbbbinghe");
-        User user5 = user( "bingbing");
+        User user1 = user("binghe");
+        User user2 = user("bing");
+        User user3 = user("jinbinghe");
+        User user4 = user("bbbbinghe");
+        User user5 = user("bingbing");
 
         return List.of(
             user1, user2, user3, user4, user5
@@ -133,6 +149,43 @@ public class UserFactory {
         User user3 = user(3L,"jinbinghe");
         User user4 = user(4L,"bbbbinghe");
         User user5 = user(5L,"bingbing");
+
+        return List.of(
+            user1, user2, user3, user4, user5
+        );
+    }
+
+    public static List<User> mockLikeUsersIncludingAuthor() {
+        User user1 = user("user1");
+        User user2 = user("user2");
+        User user3 = user("user3");
+        User user4 = user("user4");
+        User user5 = user("user5");
+        User author = user("author");
+
+        return List.of(
+            user1, user2, user3, user4, user5, author
+        );
+    }
+
+    public static List<User> mockLikeUsers() {
+        User user1 = user("user1", "http://img.com");
+        User user2 = user("user2", "http://img.com");
+        User user3 = user("user3", "http://img.com");
+        User user4 = user("user4", "http://img.com");
+        User user5 = user("user5", "http://img.com");
+
+        return List.of(
+            user1, user2, user3, user4, user5
+        );
+    }
+
+    public static List<User> mockLikeUsersWithId() {
+        User user1 = user(1L, "user1", "http://img.com");
+        User user2 = user(2L, "user2", "http://img.com");
+        User user3 = user(3L, "user3", "http://img.com");
+        User user4 = user(4L, "user4", "http://img.com");
+        User user5 = user(5L, "user5", "http://img.com");
 
         return List.of(
             user1, user2, user3, user4, user5

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_likeUsers.java
@@ -1,0 +1,183 @@
+package com.woowacourse.pickgit.integration.post;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.pickgit.common.factory.PostFactory;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
+import com.woowacourse.pickgit.exception.post.PostNotFoundException;
+import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
+import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.repository.PostRepository;
+import com.woowacourse.pickgit.user.domain.User;
+import com.woowacourse.pickgit.user.domain.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Import(InfrastructureTestConfiguration.class)
+@Transactional
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ActiveProfiles("test")
+public class PostFeedServiceIntegrationTest_likeUsers {
+
+    @Autowired
+    private PostFeedService postFeedService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("로그인한 사용자는 게시물에 좋아요한 유저 리스트를 조회한다 - 성공")
+    @Test
+    void likeUsers_LoginUser_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto("author", false);
+
+        User author = UserFactory.user("author");
+        userRepository.save(author);
+
+        List<User> likeUsers = UserFactory.mockLikeUsers();
+        Post post = PostFactory.post(author);
+        likePost(likeUsers, post);
+        authorFollowSomeUsers(author, likeUsers);
+
+        Post savedPost = postRepository.save(post);
+        Long postId = savedPost.getId();
+
+        List<LikeUsersResponseDto> expectedResponse =
+            createLikeUserResponseDtoForLoginUser(likeUsers);
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("게스트는 게시물에 좋아요한 유저 리스트를 조회한다 - 성공")
+    @Test
+    void likeUsers_GuestUser_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        User author = UserFactory.user("author");
+        userRepository.save(author);
+
+        List<User> likeUsers = UserFactory.mockLikeUsers();
+        Post post = PostFactory.post(author);
+        likePost(likeUsers, post);
+        authorFollowSomeUsers(author, likeUsers);
+
+        Post savedPost = postRepository.save(post);
+        Long postId = savedPost.getId();
+
+        List<LikeUsersResponseDto> expectedResponse =
+            createLikeUserResponseForGuest(likeUsers);
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("좋아요가 없는 포스트 조회 시 빈 배열을 반환한다. - 게스트/성공")
+    @Test
+    void likeUsers_EmptyLikes_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        User author = UserFactory.user("author");
+        userRepository.save(author);
+
+        Post savedPost = postRepository.save(PostFactory.post(author));
+        Long postId = savedPost.getId();
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse).isEmpty();
+    }
+
+    @DisplayName("없는 포스트 조회 500예외가 발생한다. - 게스트/실패")
+    @Test
+    void likeUsers_InvalidPost_500Exception() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        Long postId = 1L;
+
+        // when then
+        assertThatThrownBy(
+            () -> postFeedService.likeUsers(authUserForPostRequestDto, postId)
+        ).isInstanceOf(PostNotFoundException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "P0002");
+    }
+
+    private void likePost(List<User> likeUsers, Post post) {
+        likeUsers.forEach(user -> {
+            userRepository.save(user);
+            post.like(user);
+        });
+    }
+
+    private void authorFollowSomeUsers(User author, List<User> likeUsers) {
+        for (int i = 0; i < 2; i++) {
+            User user = likeUsers.get(i);
+            author.follow(user);
+        }
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseDtoForLoginUser(
+        List<User> likeUsers
+    ) {
+        return likeUsers.stream()
+            .map(user -> {
+                    if (isFollowingUser(likeUsers, user)) {
+                        return new LikeUsersResponseDto(
+                            user.getImage(), user.getName(), true
+                        );
+                    }
+                    return new LikeUsersResponseDto(
+                        user.getImage(), user.getName(), false
+                    );
+                }).collect(toList());
+    }
+
+    private boolean isFollowingUser(List<User> likeUsers, User user) {
+        return user.getName().equals(likeUsers.get(0).getName())
+            || user.getName().equals(likeUsers.get(1).getName());
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseForGuest(List<User> likeUsers) {
+        return likeUsers.stream()
+            .map(
+                user -> new LikeUsersResponseDto(user.getImage(), user.getName(), null)
+            ).collect(toList());
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_likeUsers.java
@@ -22,12 +22,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @Import(InfrastructureTestConfiguration.class)
 @Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 public class PostFeedServiceIntegrationTest_likeUsers {
 
@@ -130,7 +133,7 @@ public class PostFeedServiceIntegrationTest_likeUsers {
         AuthUserForPostRequestDto authUserForPostRequestDto =
             new AuthUserForPostRequestDto(null, true);
 
-        Long postId = 1L;
+        Long postId = 10L;
 
         // when then
         assertThatThrownBy(
@@ -158,15 +161,15 @@ public class PostFeedServiceIntegrationTest_likeUsers {
     ) {
         return likeUsers.stream()
             .map(user -> {
-                    if (isFollowingUser(likeUsers, user)) {
-                        return new LikeUsersResponseDto(
-                            user.getImage(), user.getName(), true
-                        );
-                    }
+                if (isFollowingUser(likeUsers, user)) {
                     return new LikeUsersResponseDto(
-                        user.getImage(), user.getName(), false
+                        user.getImage(), user.getName(), true
                     );
-                }).collect(toList());
+                }
+                return new LikeUsersResponseDto(
+                    user.getImage(), user.getName(), false
+                );
+            }).collect(toList());
     }
 
     private boolean isFollowingUser(List<User> likeUsers, User user) {
@@ -181,3 +184,5 @@ public class PostFeedServiceIntegrationTest_likeUsers {
             ).collect(toList());
     }
 }
+
+

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_search.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostFeedServiceIntegrationTest_search.java
@@ -30,6 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class PostFeedServiceIntegrationTest_search {
 
     @Autowired

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/post/PostServiceIntegrationTest_likeUsers.java
@@ -9,6 +9,7 @@ import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.post.PostNotFoundException;
 import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.PostService;
 import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
 import com.woowacourse.pickgit.post.domain.Post;
@@ -32,10 +33,10 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
-public class PostFeedServiceIntegrationTest_likeUsers {
+public class PostServiceIntegrationTest_likeUsers {
 
     @Autowired
-    private PostFeedService postFeedService;
+    private PostService postService;
 
     @Autowired
     private UserRepository userRepository;
@@ -65,7 +66,7 @@ public class PostFeedServiceIntegrationTest_likeUsers {
             createLikeUserResponseDtoForLoginUser(likeUsers);
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -96,7 +97,7 @@ public class PostFeedServiceIntegrationTest_likeUsers {
             createLikeUserResponseForGuest(likeUsers);
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -119,7 +120,7 @@ public class PostFeedServiceIntegrationTest_likeUsers {
         Long postId = savedPost.getId();
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -137,7 +138,7 @@ public class PostFeedServiceIntegrationTest_likeUsers {
 
         // when then
         assertThatThrownBy(
-            () -> postFeedService.likeUsers(authUserForPostRequestDto, postId)
+            () -> postService.likeUsers(authUserForPostRequestDto, postId)
         ).isInstanceOf(PostNotFoundException.class)
             .hasFieldOrPropertyWithValue("errorCode", "P0002");
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/user/UserServiceIntegrationTest.java
@@ -635,6 +635,7 @@ class UserServiceIntegrationTest {
                 .build();
             userService.followUser(requestDto);
         });
+
         for (int i = 0; i < 3; i++) {
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(authUserRequestDto)
@@ -679,6 +680,7 @@ class UserServiceIntegrationTest {
 
         usersInDb.forEach(mockUser -> {
             AuthUserForUserRequestDto targetAuthDto = createLoginAuthUserRequestDto("target");
+
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(targetAuthDto)
                 .targetName(mockUser.getName())
@@ -721,7 +723,9 @@ class UserServiceIntegrationTest {
         userRepository.save(targetUser);
 
         usersInDb.forEach(mockUser -> {
-            AuthUserForUserRequestDto mockUserAuthDto = createLoginAuthUserRequestDto(mockUser.getName());
+            AuthUserForUserRequestDto mockUserAuthDto =
+                createLoginAuthUserRequestDto(mockUser.getName());
+
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(mockUserAuthDto)
                 .targetName("target")
@@ -729,6 +733,7 @@ class UserServiceIntegrationTest {
                 .build();
             userService.followUser(requestDto);
         });
+
         for (int i = 0; i < 3; i++) {
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(authUserRequestDto)
@@ -773,6 +778,7 @@ class UserServiceIntegrationTest {
 
         usersInDb.forEach(mockUser -> {
             AuthUserForUserRequestDto mockUserAuthDto = createLoginAuthUserRequestDto(mockUser.getName());
+
             FollowRequestDto requestDto = FollowRequestDto.builder()
                 .authUserRequestDto(mockUserAuthDto)
                 .targetName("target")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostFeedServiceTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostFeedServiceTest_likeUsers.java
@@ -1,0 +1,213 @@
+package com.woowacourse.pickgit.unit.post.application;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.woowacourse.pickgit.common.factory.PostFactory;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.exception.post.PostNotFoundException;
+import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
+import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.like.Like;
+import com.woowacourse.pickgit.post.domain.like.Likes;
+import com.woowacourse.pickgit.post.domain.repository.PostRepository;
+import com.woowacourse.pickgit.user.domain.User;
+import com.woowacourse.pickgit.user.domain.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PostFeedServiceTest_likeUsers {
+
+    private static final String IMAGE_URL = "http://img.com";
+
+    @InjectMocks
+    private PostFeedService postFeedService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @DisplayName("로그인한 사용자는 게시물에 좋아요한 유저 리스트를 조회한다 - 성공")
+    @Test
+    void likeUsers_LoginUser_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto("author", false);
+
+        Long postId = 1L;
+        User author = UserFactory.user("author");
+
+        List<User> likeUsers = UserFactory.mockLikeUsersWithId();
+        followSomeUsers(author, likeUsers);
+
+        Likes likes = new Likes(List.of(
+            new Like(PostFactory.post(), likeUsers.get(0)),
+            new Like(PostFactory.post(), likeUsers.get(1)),
+            new Like(PostFactory.post(), likeUsers.get(2)),
+            new Like(PostFactory.post(), likeUsers.get(3)),
+            new Like(PostFactory.post(), likeUsers.get(4))
+        ));
+
+        Post post = PostFactory.likedPost(author, likes);
+
+        given(postRepository.findPostWithLikeUsers(postId))
+            .willReturn(Optional.of(post));
+        given(userRepository.findByBasicProfile_Name("author"))
+            .willReturn(Optional.of(author));
+
+        List<LikeUsersResponseDto> expectedResponse =
+            createLikeUserResponseDtoForLoginUser(post.getLikeUsers());
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+
+        verify(postRepository, times(1))
+            .findPostWithLikeUsers(postId);
+        verify(userRepository, times(1))
+            .findByBasicProfile_Name("author");
+    }
+
+    private void followSomeUsers(User author, List<User> likeUsers) {
+        author.follow(likeUsers.get(0));
+        author.follow(likeUsers.get(1));
+    }
+
+    @DisplayName("게스트는 게시물에 좋아요한 유저 리스트를 조회한다 - 성공")
+    @Test
+    void likeUsers_GuestUser_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        Long postId = 1L;
+        User author = UserFactory.user("author");
+
+        Likes likes = new Likes(List.of(
+            new Like(PostFactory.post(), UserFactory.user("user1", IMAGE_URL)),
+            new Like(PostFactory.post(), UserFactory.user("user2", IMAGE_URL)),
+            new Like(PostFactory.post(), UserFactory.user("user3", IMAGE_URL))
+        ));
+
+        Post post = PostFactory.likedPost(author, likes);
+
+        given(postRepository.findPostWithLikeUsers(postId))
+            .willReturn(Optional.of(post));
+
+        List<LikeUsersResponseDto> expectedResponse =
+            createLikeUserResponseForGuest(post.getLikeUsers());
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+
+        verify(postRepository, times(1))
+            .findPostWithLikeUsers(postId);
+        verify(userRepository, never())
+            .findByBasicProfile_Name("author");
+    }
+
+    @DisplayName("좋아요가 없는 포스트 조회 시 빈 배열을 반환한다. - 게스트/성공")
+    @Test
+    void likeUsers_EmptyLikes_Success() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        Long postId = 1L;
+        Post post = PostFactory.post(UserFactory.user("author"));
+
+        given(postRepository.findPostWithLikeUsers(postId))
+            .willReturn(Optional.of(post));
+
+        // when
+        List<LikeUsersResponseDto> actualResponse = postFeedService
+            .likeUsers(authUserForPostRequestDto, postId);
+
+        // then
+        assertThat(actualResponse).isEmpty();
+
+        verify(postRepository, times(1))
+            .findPostWithLikeUsers(postId);
+        verify(userRepository, never())
+            .findByBasicProfile_Name("author");
+    }
+
+    @DisplayName("없는 포스트 조회 500예외가 발생한다. - 게스트/실패")
+    @Test
+    void likeUsers_InvalidPost_500Exception() {
+        // given
+        AuthUserForPostRequestDto authUserForPostRequestDto =
+            new AuthUserForPostRequestDto(null, true);
+
+        Long postId = 1L;
+
+        given(postRepository.findPostWithLikeUsers(postId))
+            .willReturn(Optional.empty());
+
+        // when then
+        assertThatThrownBy(
+            () -> postFeedService.likeUsers(authUserForPostRequestDto, postId)
+        ).isInstanceOf(PostNotFoundException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "P0002");
+
+        verify(postRepository, times(1))
+            .findPostWithLikeUsers(postId);
+        verify(userRepository, never())
+            .findByBasicProfile_Name("author");
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseDtoForLoginUser(
+        List<User> likeUsers
+    ) {
+        return likeUsers.stream()
+            .map(user -> {
+                if (isFollowingUser(likeUsers, user)) {
+                    return new LikeUsersResponseDto(
+                        user.getImage(), user.getName(), true
+                    );
+                }
+                return new LikeUsersResponseDto(
+                    user.getImage(), user.getName(), false
+                );
+            }).collect(toList());
+    }
+
+    private boolean isFollowingUser(List<User> likeUsers, User user) {
+        return user.getName().equals(likeUsers.get(0).getName())
+            || user.getName().equals(likeUsers.get(1).getName());
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseForGuest(List<User> likeUsers) {
+        return likeUsers.stream()
+            .map(
+                user -> new LikeUsersResponseDto(user.getImage(), user.getName(), null)
+            ).collect(toList());
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/application/PostServiceTest_likeUsers.java
@@ -12,6 +12,7 @@ import com.woowacourse.pickgit.common.factory.PostFactory;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.exception.post.PostNotFoundException;
 import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.PostService;
 import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
 import com.woowacourse.pickgit.post.domain.Post;
@@ -30,12 +31,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class PostFeedServiceTest_likeUsers {
+public class PostServiceTest_likeUsers {
 
     private static final String IMAGE_URL = "http://img.com";
 
     @InjectMocks
-    private PostFeedService postFeedService;
+    private PostService postService;
 
     @Mock
     private UserRepository userRepository;
@@ -75,7 +76,7 @@ public class PostFeedServiceTest_likeUsers {
             createLikeUserResponseDtoForLoginUser(post.getLikeUsers());
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -119,7 +120,7 @@ public class PostFeedServiceTest_likeUsers {
             createLikeUserResponseForGuest(post.getLikeUsers());
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -147,7 +148,7 @@ public class PostFeedServiceTest_likeUsers {
             .willReturn(Optional.of(post));
 
         // when
-        List<LikeUsersResponseDto> actualResponse = postFeedService
+        List<LikeUsersResponseDto> actualResponse = postService
             .likeUsers(authUserForPostRequestDto, postId);
 
         // then
@@ -173,7 +174,7 @@ public class PostFeedServiceTest_likeUsers {
 
         // when then
         assertThatThrownBy(
-            () -> postFeedService.likeUsers(authUserForPostRequestDto, postId)
+            () -> postService.likeUsers(authUserForPostRequestDto, postId)
         ).isInstanceOf(PostNotFoundException.class)
             .hasFieldOrPropertyWithValue("errorCode", "P0002");
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.pickgit.unit.post.domain;
 
-import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/domain/PostRepositoryTest_likeUsers.java
@@ -1,0 +1,97 @@
+package com.woowacourse.pickgit.unit.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.pickgit.common.factory.PostFactory;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.config.JpaTestConfiguration;
+import com.woowacourse.pickgit.exception.post.PostNotFoundException;
+import com.woowacourse.pickgit.post.domain.Post;
+import com.woowacourse.pickgit.post.domain.like.Like;
+import com.woowacourse.pickgit.post.domain.repository.PostRepository;
+import com.woowacourse.pickgit.user.domain.User;
+import com.woowacourse.pickgit.user.domain.UserRepository;
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnitUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@Import(JpaTestConfiguration.class)
+@DataJpaTest
+public class PostRepositoryTest_likeUsers {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @DisplayName("Post를 조회할 때 연결된 중간테이블 Like + Like에 속한 User까지 모두 즉시로딩으로 가져온다.")
+    @Test
+    void findPostWithLikeUsers_getPost_Success() {
+        // given
+        PersistenceUnitUtil persistenceUnitUtil =
+            entityManagerFactory.getPersistenceUnitUtil();
+
+        User author = UserFactory.user("author");
+        userRepository.save(author);
+
+        List<User> likeUsers = UserFactory.mockLikeUsers();
+        Post post = PostFactory.post(author);
+        likeUsers.forEach(user -> {
+            userRepository.save(user);
+            post.like(user);
+        });
+
+        Post savedPost = postRepository.save(post);
+        testEntityManager.flush();
+        testEntityManager.clear();
+
+        // when
+        Post findPost =
+            postRepository.findPostWithLikeUsers(savedPost.getId())
+                .orElseThrow(PostNotFoundException::new);
+
+        List<Like> likes = findPost.getLikes().getLikes();
+
+        // then
+        assertThat(findPost).isNotNull();
+        assertThat(findPost.getLikeCounts()).isEqualTo(likeUsers.size());
+        likes.forEach(like ->
+            assertThat(persistenceUnitUtil.isLoaded(like, "user")).isTrue()
+        );
+
+
+    }
+
+    @DisplayName("좋아요가 없는 게시물도 가져온다.")
+    @Test
+    void findPostWithLikeUsers_noLikes_Success() {
+        // given
+        User author = UserFactory.user("author");
+        userRepository.save(author);
+
+        Post savedPost = postRepository.save(PostFactory.post(author));
+        testEntityManager.flush();
+        testEntityManager.clear();
+
+        // when
+        Post findPost =
+            postRepository.findPostWithLikeUsers(savedPost.getId())
+                .orElseThrow(PostNotFoundException::new);
+
+        // then
+        assertThat(findPost).isNotNull();
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostControllerTest_likeUsers.java
@@ -27,9 +27,10 @@ import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.common.factory.UserFactory;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
-import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.PostService;
 import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
 import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
+import com.woowacourse.pickgit.post.presentation.PostController;
 import com.woowacourse.pickgit.post.presentation.PostFeedController;
 import com.woowacourse.pickgit.user.domain.User;
 import java.util.List;
@@ -48,9 +49,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureRestDocs
 @Import(InfrastructureTestConfiguration.class)
-@WebMvcTest(PostFeedController.class)
+@WebMvcTest(PostController.class)
 @ActiveProfiles("test")
-public class PostFeedControllerTest_likeUsers {
+public class PostControllerTest_likeUsers {
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -59,7 +60,7 @@ public class PostFeedControllerTest_likeUsers {
     private MockMvc mockMvc;
 
     @MockBean
-    private PostFeedService postfeedService;
+    private PostService postService;
 
     @MockBean
     private OAuthService oAuthService;
@@ -78,7 +79,7 @@ public class PostFeedControllerTest_likeUsers {
         given(oAuthService.validateToken(token)).willReturn(true);
         given(oAuthService.findRequestUserByToken(token))
             .willReturn(new LoginUser("author", "token"));
-        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+        given(postService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
             .willReturn(likeUsersResponseDto);
 
         // when
@@ -104,7 +105,7 @@ public class PostFeedControllerTest_likeUsers {
         verify(oAuthService, times(1)).validateToken("token");
         verify(oAuthService, times(1))
             .findRequestUserByToken("token");
-        verify(postfeedService, times(1))
+        verify(postService, times(1))
             .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
 
         // restdocs
@@ -134,7 +135,7 @@ public class PostFeedControllerTest_likeUsers {
         // mock
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(new GuestUser());
-        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+        given(postService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
             .willReturn(likeUsersResponseDto);
 
         // when
@@ -158,7 +159,7 @@ public class PostFeedControllerTest_likeUsers {
 
         verify(oAuthService, times(1))
             .findRequestUserByToken(any());
-        verify(postfeedService, times(1))
+        verify(postService, times(1))
             .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
 
         // restdocs
@@ -182,7 +183,7 @@ public class PostFeedControllerTest_likeUsers {
         // mock
         given(oAuthService.findRequestUserByToken(any()))
             .willReturn(new GuestUser());
-        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+        given(postService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
             .willReturn(likeUsersResponseDto);
 
         // when
@@ -206,7 +207,7 @@ public class PostFeedControllerTest_likeUsers {
 
         verify(oAuthService, times(1))
             .findRequestUserByToken(any());
-        verify(postfeedService, times(1))
+        verify(postService, times(1))
             .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
 
         // restdocs

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_likeUsers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_likeUsers.java
@@ -1,0 +1,249 @@
+package com.woowacourse.pickgit.unit.post.presentation;
+
+import static com.woowacourse.pickgit.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.woowacourse.pickgit.docs.ApiDocumentUtils.getDocumentResponse;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.pickgit.authentication.application.OAuthService;
+import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
+import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
+import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
+import com.woowacourse.pickgit.post.application.PostFeedService;
+import com.woowacourse.pickgit.post.application.dto.request.AuthUserForPostRequestDto;
+import com.woowacourse.pickgit.post.application.dto.response.LikeUsersResponseDto;
+import com.woowacourse.pickgit.post.presentation.PostFeedController;
+import com.woowacourse.pickgit.user.domain.User;
+import java.util.List;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@Import(InfrastructureTestConfiguration.class)
+@WebMvcTest(PostFeedController.class)
+@ActiveProfiles("test")
+public class PostFeedControllerTest_likeUsers {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PostFeedService postfeedService;
+
+    @MockBean
+    private OAuthService oAuthService;
+
+    @DisplayName("게시물의 좋아요 리스트를 조회할 수 있다. - 로그인/성공")
+    @Test
+    void searchLikeUsers_LoginUser_Success() throws Exception {
+        String token = "token";
+        Long postId = 1L;
+        List<User> likeUsers = UserFactory.mockLikeUsersWithId();
+
+        List<LikeUsersResponseDto> likeUsersResponseDto =
+            createLikeUserResponseDtoForLoginUser(likeUsers);
+
+        // mock
+        given(oAuthService.validateToken(token)).willReturn(true);
+        given(oAuthService.findRequestUserByToken(token))
+            .willReturn(new LoginUser("author", "token"));
+        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+            .willReturn(likeUsersResponseDto);
+
+        // when
+        ResultActions perform = mockMvc
+            .perform(
+                get("/api/posts/{postId}/likes", postId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.ALL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            );
+
+        // then
+        String body = perform
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(body)
+            .isEqualTo(objectMapper.writeValueAsString(likeUsersResponseDto));
+
+        verify(oAuthService, times(1)).validateToken("token");
+        verify(oAuthService, times(1))
+            .findRequestUserByToken("token");
+        verify(postfeedService, times(1))
+            .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
+
+        // restdocs
+        perform.andDo(document("post-likeUsers-loggedIn",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer " + token)
+            ),
+            responseFields(
+                fieldWithPath("[].imageUrl").type(STRING).description("유저 이미지 URL"),
+                fieldWithPath("[].username").type(STRING).description("유저 이름"),
+                fieldWithPath("[].following").type(BOOLEAN).description("로그인 유저의 타겟 유저 팔로잉 여부")
+            )
+        ));
+    }
+
+    @DisplayName("게시물의 좋아요 리스트를 조회할 수 있다. - 비 로그인/성공")
+    @Test
+    void searchLikeUsers_GuestUser_Success() throws Exception {
+        Long postId = 1L;
+        List<User> likeUsers = UserFactory.mockLikeUsersWithId();
+
+        List<LikeUsersResponseDto> likeUsersResponseDto =
+            createLikeUserResponseForGuest(likeUsers);
+
+        // mock
+        given(oAuthService.findRequestUserByToken(any()))
+            .willReturn(new GuestUser());
+        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+            .willReturn(likeUsersResponseDto);
+
+        // when
+        ResultActions perform = mockMvc
+            .perform(
+                get("/api/posts/{postId}/likes", postId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.ALL)
+            );
+
+        // then
+        String body = perform
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(body)
+            .isEqualTo(objectMapper.writeValueAsString(likeUsersResponseDto));
+
+        verify(oAuthService, times(1))
+            .findRequestUserByToken(any());
+        verify(postfeedService, times(1))
+            .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
+
+        // restdocs
+        perform.andDo(document("post-likeUsers-unLoggedIn",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            responseFields(
+                fieldWithPath("[].imageUrl").type(STRING).description("유저 이미지 URL"),
+                fieldWithPath("[].username").type(STRING).description("유저 이름"),
+                fieldWithPath("[].following").type(BOOLEAN).description("로그인 유저의 타겟 유저 팔로잉 여부")
+            )
+        ));
+    }
+
+    @DisplayName("좋아요가 하나도 없는 게시물을 조회하면 빈 배열을 반환한다. - 비 로그인/성공")
+    @Test
+    void searchLikeUsers_EmptyLikes_Success() throws Exception {
+        Long postId = 1L;
+        List<LikeUsersResponseDto> likeUsersResponseDto = List.of();
+
+        // mock
+        given(oAuthService.findRequestUserByToken(any()))
+            .willReturn(new GuestUser());
+        given(postfeedService.likeUsers(any(AuthUserForPostRequestDto.class), anyLong()))
+            .willReturn(likeUsersResponseDto);
+
+        // when
+        ResultActions perform = mockMvc
+            .perform(
+                get("/api/posts/{postId}/likes", postId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.ALL)
+            );
+
+        // then
+        String body = perform
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(body)
+            .isEqualTo(objectMapper.writeValueAsString(likeUsersResponseDto));
+
+        verify(oAuthService, times(1))
+            .findRequestUserByToken(any());
+        verify(postfeedService, times(1))
+            .likeUsers(any(AuthUserForPostRequestDto.class), anyLong());
+
+        // restdocs
+        perform.andDo(document("post-likeUsers-emptyLikes",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            responseFields(
+                fieldWithPath("[]").type(LIST).description("빈 배열")
+            )
+        ));
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseDtoForLoginUser(
+        List<User> likeUsers
+    ) {
+        return likeUsers.stream()
+            .map(user -> {
+                if (isFollowingUser(likeUsers, user)) {
+                    return new LikeUsersResponseDto(
+                        user.getImage(), user.getName(), true
+                    );
+                }
+                return new LikeUsersResponseDto(
+                    user.getImage(), user.getName(), false
+                );
+            }).collect(toList());
+    }
+
+    private boolean isFollowingUser(List<User> likeUsers, User user) {
+        return user.getName().equals(likeUsers.get(0).getName())
+            || user.getName().equals(likeUsers.get(1).getName());
+    }
+
+    private List<LikeUsersResponseDto> createLikeUserResponseForGuest(List<User> likeUsers) {
+        return likeUsers.stream()
+            .map(
+                user -> new LikeUsersResponseDto(user.getImage(), user.getName(), null)
+            ).collect(toList());
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/application/UserServiceTest.java
@@ -234,11 +234,11 @@ class UserServiceTest {
             @Test
             void getUserProfile_FindByNameInCaseOfLoginUseIsNotFollowing_Success() {
                 //given
-                User loginUser = UserFactory.user("testUser");
+                User loginUser = UserFactory.user(1L, "testUser");
                 String loginUsername = loginUser.getName();
                 AuthUserForUserRequestDto authUserRequestDto =
                     createLoginAuthUserRequestDto(loginUsername);
-                User targetUser = UserFactory.user("testUser2");
+                User targetUser = UserFactory.user(2L, "testUser2");
                 String targetUsername = targetUser.getName();
 
                 given(userRepository.findByBasicProfile_Name(targetUsername))

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/presentation/UserSearchControllerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/presentation/UserSearchControllerTest.java
@@ -84,7 +84,7 @@ class UserSearchControllerTest {
                     .param("limit", "5")
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.ALL)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer token"));
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token"));
 
         // then
         perform


### PR DESCRIPTION
## 상세 내용
- 게시물을 좋아요한 유저 리스트를 반환한다. (페이지네이션 적용 x)
- 요청에 Auth Header가 존재한다면 로그인, 없으면 비로그인 유저로 간주한다. (게시물을 조회하는 유저 기준)
  - 로그인 유저 팔로우/팔로잉 여부 : true / false
  - 비로그인 유저 : null
<br/>

## 기타
- 페이지네이션이 불필요 하므로 fetch-join 사용했습니다. 저번에 말한 버그를 고치고 두번째 fetch join(Likes의 User 까지 즉시로딩 하는 부분)을 제거하고 2번의 쿼리로  진행할까 했지만 equals의 getClass() 을 instanceOf로 일괄적으로 바꾸는 것이 혼란이 덜 할 것 같아서 우선 업로드 합니다. 
- ~~현재 restdocs 테스트 부분이 누락되어 있는데 오늘 데모라 우선 pr 올립니다!!~~

[예외 케이스]
- 좋아요가 없는 게시물 조회 시 빈 문자열 반환
- 없는 게시물 조회시 예외 발생 

<br/>

Close #374 

