### PR TITLE
[#427] 레포 목록 검색 api 주소 수정

### DIFF
--- a/frontend/src/components/RepositorySelector/RepositorySelector.tsx
+++ b/frontend/src/components/RepositorySelector/RepositorySelector.tsx
@@ -1,9 +1,10 @@
-import { Dispatch, SetStateAction, useContext, useState } from "react";
+import { Dispatch, SetStateAction, useContext, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { ThemeContext } from "styled-components";
 import { RepositoryIcon, SearchIcon } from "../../assets/icons";
 import { FAILURE_MESSAGE, REDIRECT_MESSAGE } from "../../constants/messages";
 import { PAGE_URL } from "../../constants/urls";
+import useDebounce from "../../services/hooks/@common/useDebounce";
 import useMessageModal from "../../services/hooks/@common/useMessageModal";
 import useThrottle from "../../services/hooks/@common/useThrottle";
 import { useGithubRepositoriesQuery } from "../../services/queries";
@@ -29,6 +30,7 @@ interface Props {
 }
 
 const RepositorySelector = ({ setGithubRepositoryName, goNextStep }: Props) => {
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchKeyword, setSearchKeyword] = useState("");
   const {
     data: infiniteRepositoriesData,
@@ -54,6 +56,8 @@ const RepositorySelector = ({ setGithubRepositoryName, goNextStep }: Props) => {
   const handleErrorConfirm = () => {
     history.push(PAGE_URL.HOME);
   };
+
+  const changeSearchKeyword = useDebounce(() => {}, 300);
 
   const handleSearchInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;

--- a/frontend/src/constants/urls.ts
+++ b/frontend/src/constants/urls.ts
@@ -42,7 +42,9 @@ export const API_URL = {
   SELF_PROFILE_DESCRIPTION: "/profiles/me/description",
   ADD_POSTS: "/posts",
   GITHUB_REPOSITORIES: (keyword: string, page: number, limit: number) =>
-    `/github/repositories?keyword=${keyword}&page=${page}&limit=${limit}`,
+    keyword === ""
+      ? `/github/repositories?&page=${page}&limit=${limit}`
+      : `/github/search/repositories?keyword=${keyword}&page=${page}&limit=${limit}`,
   USER_PROFILE: (username: string) => `/profiles/${username}`,
   USER_PROFILE_FOLLOW: (username: string, githubFollowing: boolean) =>
     `/profiles/${username}/followings?githubFollowing=${githubFollowing}`,


### PR DESCRIPTION
## 상세 내용

- 검색어가 없을 때는 기본 레포 목록 가져오기 api 를, 검색어가 있을 때는 레포 목록 검색 api를 사용하도록 변경

<br/>

Close#427
