### PR TITLE
[#438] 테스트에서 유저 이름을 기반으로 토큰을 생성하도록 변경

### DIFF
--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/acceptance/user/UserAcceptance_GetFollowingsAndFollowers.java
@@ -88,7 +88,7 @@ class UserAcceptance_GetFollowingsAndFollowers {
         // when
         List<UserSearchResponse> response = PickGitRequest
             .get(FOLLOWINGS_API_URL, "target", "0", "10")
-            .withUser()
+            .withUser("testUser")
             .extract()
             .as(new TypeRef<>() {
             });
@@ -181,7 +181,7 @@ class UserAcceptance_GetFollowingsAndFollowers {
         // when
         List<UserSearchResponse> response = PickGitRequest
             .get(FOLLOWERS_API_URL, "target", "0", "10")
-            .withUser()
+            .withUser("testUser")
             .extract()
             .as(new TypeRef<>() {
             });

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockGithubOAuthClient.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/mockapi/MockGithubOAuthClient.java
@@ -12,13 +12,13 @@ public class MockGithubOAuthClient implements OAuthClient {
 
     @Override
     public String getAccessToken(String code) {
-        return "Bearer testAccessToken";
+        return code;
     }
 
     @Override
     public OAuthProfileResponse getGithubProfile(String githubAccessToken) {
         return new OAuthProfileResponse(
-            "testUser",
+            githubAccessToken,
             "https://github.com/testImage.jpg",
             "testDescription",
             "https://github.com/bperhaps",

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/request_builder/LoginBuilder.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/common/request_builder/LoginBuilder.java
@@ -7,10 +7,12 @@ import com.woowacourse.pickgit.common.request_builder.parameters.Parameters;
 import io.restassured.specification.RequestSpecification;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDateTime;
 import org.apache.http.entity.ContentType;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.util.DigestUtils;
 
 public class LoginBuilder<T extends Parameters> {
 
@@ -34,30 +36,39 @@ public class LoginBuilder<T extends Parameters> {
     }
 
     public T withUser() {
-        return withUser(requestLogin());
+        return withUser(createRandomString());
     }
 
-    public T withUser(String token) {
+    private String createRandomString() {
+        String seed = String.valueOf(LocalDateTime.now().getNano());
+        return DigestUtils.md5DigestAsHex(seed.getBytes());
+    }
+
+    public T withUser(String name) {
+        return setOauth2ToSpec(requestLogin(name));
+    }
+
+    private T setOauth2ToSpec(String token) {
         spec = given().log().all().auth().oauth2(token);
 
         return getParameterBuilder();
     }
 
-    public T withGuest() {
-        spec = given().log().all();
-        return getParameterBuilder();
-    }
-
-    private String requestLogin() {
+    private String requestLogin(String code) {
         return given().log().all()
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .when()
-            .get("/api/afterlogin?code=1234")
+            .get("/api/afterlogin?code={code}", code)
             .then().log().all()
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(TokenDto.class)
             .getToken();
+    }
+
+    public T withGuest() {
+        spec = given().log().all();
+        return getParameterBuilder();
     }
 
     private T getParameterBuilder() {

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/comment/CommentServiceIntegrationTest_queryComments.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/comment/CommentServiceIntegrationTest_queryComments.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pickgit.integration.comment;
 
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.AssertionsForClassTypes.in;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.woowacourse.pickgit.comment.application.CommentService;
@@ -9,6 +8,7 @@ import com.woowacourse.pickgit.comment.application.dto.request.QueryCommentReque
 import com.woowacourse.pickgit.comment.application.dto.response.CommentResponseDto;
 import com.woowacourse.pickgit.comment.domain.Comment;
 import com.woowacourse.pickgit.common.factory.UserFactory;
+import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.post.domain.Post;
 import com.woowacourse.pickgit.post.domain.repository.PostRepository;
 import com.woowacourse.pickgit.user.domain.User;
@@ -18,17 +18,19 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.transaction.Transactional;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.DigestUtils;
 
+@Import(InfrastructureTestConfiguration.class)
 @SpringBootTest
+@ActiveProfiles("test")
 public class CommentServiceIntegrationTest_queryComments {
     @Autowired
     private CommentService commentService;


### PR DESCRIPTION
## 상세 내용
![image](https://user-images.githubusercontent.com/33603557/129128304-ca6f3023-aca0-4c6e-b162-38aa76e43ba2.png)
![image](https://user-images.githubusercontent.com/33603557/129128362-8f012dcb-21eb-4042-92dc-7f28274ef2e8.png)

로그인 요청 시 전송하는 code에 이름을 담아 보내면, 이름을 기반으로 Token을 전송하도록 변경하였습니다.
PickgitRequest 를 사용하면, `withUser({userName})` 을 통해서 특정 유저의 토큰으로 로그인 요청을 보낼 수 있습니다.
파라메터 없는 `withUser()` 는 랜덤 유저로 전송하도록 변경하였습니다.

![image](https://user-images.githubusercontent.com/33603557/129128702-3330d3fc-c5e5-4b58-98d6-a8a50da299b7.png)
이런식으로 전송하면 testUser라는 유저의 토큰으로 전송됨.

<br/>

## 기타

<br/>

Close #438 
