### PR TITLE
[#444] 피드 조회시 함께 오는 댓글의 갯수를 3개로 제한

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostDtoAssembler.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/application/PostDtoAssembler.java
@@ -49,6 +49,7 @@ public class PostDtoAssembler {
         return post.getComments()
             .stream()
             .map(toCommentResponse())
+            .limit(3)
             .collect(toList());
     }
 


### PR DESCRIPTION
## 상세 내용

현재는 단순 limit으로 제한하였으나, 추후 설계 변경이 일어날 경우 전체 코드가 변경되기에  기능 구현에만 초점을 두겠습니다.
<br/>

## 기타

<br/>

Close #444
