### PR TITLE
[#449] 게시글 좋아요 이용자 목록 페이지 이동 라우팅이 되지 않는 문제 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import FollowingList from "./pages/FollowingUserListPage/FollowingList";
 import FollowerList from "./pages/FollowerList/FollowerList";
 import OneDepthStepHeader from "./components/OneDepthStepHeader/OneDepthStepHeader";
 import CommentsPage from "./pages/CommentsPage/CommentsPage";
+import PostLikePeoplePage from "./pages/PostLikePeoplePage/PostLikePeoplePage";
 
 const App = () => {
   const { currentUsername, login, logout } = useContext(UserContext);
@@ -114,6 +115,9 @@ const App = () => {
         </Route>
         <Route path={PAGE_URL.POST_COMMENTS}>
           <CommentsPage />
+        </Route>
+        <Route path={PAGE_URL.POST_LIKE_PEOPLE}>
+          <PostLikePeoplePage />
         </Route>
         <Redirect to="/" />
       </Switch>

--- a/frontend/src/components/Feed/Feed.tsx
+++ b/frontend/src/components/Feed/Feed.tsx
@@ -91,6 +91,11 @@ const Feed = ({ infinitePostsData, queryKey }: Props) => {
       return;
     }
 
+    if (selectedPost.likesCount === 0) {
+      pushSnackbarMessage(WARNING_MESSAGE.NO_ONE_LIKE_POST);
+      return;
+    }
+
     history.push({
       pathname: PAGE_URL.POST_LIKE_PEOPLE,
       state: selectedPost.id,

--- a/frontend/src/components/UserList/UserList.tsx
+++ b/frontend/src/components/UserList/UserList.tsx
@@ -20,7 +20,7 @@ export interface Props {
   follow: ReturnType<typeof useFollow>;
   refetch: (
     options?: RefetchOptions | undefined
-  ) => Promise<QueryObserverResult<InfiniteData<UserItem[] | null>, AxiosError<ErrorResponse>>>;
+  ) => Promise<QueryObserverResult<InfiniteData<UserItem[] | null> | UserItem[], AxiosError<ErrorResponse>>>;
 }
 
 const UserList = ({ isFetchingNextPage, onIntersect, users, follow, refetch }: Props) => {

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -36,6 +36,7 @@ export const WARNING_MESSAGE = {
   GITHUB_FOLLOWING: "깃허브 계정에서도 팔로우 하시겠습니까?",
   GITHUB_UNFOLLOWING: "깃허브 계정에서도 팔로우 취소 하시겠습니까?",
   COMMENT_DELETE: "정말로 댓글을 삭제하시겠습니까?",
+  NO_ONE_LIKE_POST: "해당 포스트에 좋아요를 누른 사람이 없습니다.",
 };
 
 export const REDIRECT_MESSAGE = {

--- a/frontend/src/constants/urls.ts
+++ b/frontend/src/constants/urls.ts
@@ -63,8 +63,7 @@ export const API_URL = {
   AFTER_LOGIN: (code: string) => `afterlogin?code=${code}`,
   POST: (postId: number) => `/posts/${postId}`,
   POSTS: (page: number, limit: number) => `/posts?page=${page}&limit=${limit}`,
-  POST_LIKE_PEOPLE: (postId: number, page: number, limit: number) =>
-    `/posts/${postId}/likes?page=${page}&limit=${limit}`,
+  POST_LIKE_PEOPLE: (postId: number) => `/posts/${postId}/likes`,
   POST_LIKES: (postId: number) => `/posts/${postId}/likes`,
   POST_COMMENT: (postId: number, commentId?: number) => `/posts/${postId}/comments${commentId ? `/${commentId}` : ""}`,
   POST_COMMENTS: (postId: number, page: number, limit: number) =>

--- a/frontend/src/pages/PostLikePeoplePage/PostLikePeoplePage.tsx
+++ b/frontend/src/pages/PostLikePeoplePage/PostLikePeoplePage.tsx
@@ -9,11 +9,10 @@ import useFollow from "../../services/hooks/useFollow";
 
 const PostLikePeoplePage = () => {
   const { state: postId } = useLocation<Post["id"]>();
-  const { infinitePostLikePeople, isLoading, isFetching, isError, getNextPostLikePeople, refetch } =
-    usePostLikePeople(postId);
+  const { postLikePeople, isLoading, isError, refetch } = usePostLikePeople(postId);
   const follow = useFollow();
 
-  if (isError || !infinitePostLikePeople) {
+  if (isError || !postLikePeople) {
     return <div>에러!!</div>;
   }
 
@@ -25,15 +24,13 @@ const PostLikePeoplePage = () => {
     );
   }
 
-  const postLikePeople = getItemsFromPages<UserItem>(infinitePostLikePeople.pages);
-
   return (
     <Container>
       <UserList
         key="post-like-user"
         users={postLikePeople}
-        isFetchingNextPage={isFetching}
-        onIntersect={getNextPostLikePeople}
+        isFetchingNextPage={false}
+        onIntersect={() => {}}
         follow={follow}
         refetch={refetch}
       />

--- a/frontend/src/services/hooks/usePostLikePeople.ts
+++ b/frontend/src/services/hooks/usePostLikePeople.ts
@@ -2,25 +2,12 @@ import { Post } from "../../@types";
 import { usePostLikePeopleQuery } from "../queries/postLikePeople";
 
 const usePostLikePeople = (postId: Post["id"]) => {
-  const {
-    data: infinitePostLikePeople,
-    isError,
-    isLoading,
-    isFetching,
-    fetchNextPage,
-    refetch,
-  } = usePostLikePeopleQuery(postId);
-
-  const getNextPostLikePeople = () => {
-    fetchNextPage();
-  };
+  const { data: postLikePeople, isError, isLoading, refetch } = usePostLikePeopleQuery(postId);
 
   return {
-    infinitePostLikePeople,
+    postLikePeople,
     isError,
     isLoading,
-    isFetching,
-    getNextPostLikePeople,
     refetch,
   };
 };

--- a/frontend/src/services/queries/postLikePeople.ts
+++ b/frontend/src/services/queries/postLikePeople.ts
@@ -1,22 +1,16 @@
 import { AxiosError } from "axios";
-import { useInfiniteQuery } from "react-query";
+import { useQuery } from "react-query";
 import { ErrorResponse, Post, UserItem } from "../../@types";
 import { QUERY } from "../../constants/queries";
 import { getAccessToken } from "../../storage/storage";
 import { requestGetPostLikePeople } from "../requests/postLikePeople";
 
 export const usePostLikePeopleQuery = (postId: Post["id"]) => {
-  return useInfiniteQuery<UserItem[], AxiosError<ErrorResponse>, UserItem[], [string, number]>(
+  return useQuery<UserItem[], AxiosError<ErrorResponse>, UserItem[], [string, number]>(
     [QUERY.GET_POST_LIKE_PEOPLE, postId],
-    async ({ pageParam = 0, queryKey }) => {
+    async ({ queryKey }) => {
       const [, postIdParam] = queryKey;
-      return requestGetPostLikePeople(postIdParam, pageParam, getAccessToken());
-    },
-    {
-      getNextPageParam: (_, pages) => {
-        return pages.length;
-      },
-      cacheTime: 0,
+      return requestGetPostLikePeople(postIdParam, getAccessToken());
     }
   );
 };

--- a/frontend/src/services/requests/postLikePeople.ts
+++ b/frontend/src/services/requests/postLikePeople.ts
@@ -1,17 +1,13 @@
 import axios from "axios";
 import { Post, UserItem } from "../../@types";
-import { LIMIT } from "../../constants/limits";
 import { API_URL } from "../../constants/urls";
 
-export const requestGetPostLikePeople = async (postId: Post["id"], pageParam: number, accessToken: string | null) => {
-  const response = await axios.get<UserItem[]>(
-    API_URL.POST_LIKE_PEOPLE(postId, pageParam, LIMIT.POST_LIKE_PERSON_COUNT_PER_FETCH),
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
+export const requestGetPostLikePeople = async (postId: Post["id"], accessToken: string | null) => {
+  const response = await axios.get<UserItem[]>(API_URL.POST_LIKE_PEOPLE(postId), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
   return response.data;
 };


### PR DESCRIPTION
## 상세 내용

- 좋아요가 0 명일 경우 이용자에게 피드백 해주고 페이지 이동이 일어나지 않도록 변경

Close #449
