### PR TITLE
[#451] classname 파싱 에러 해결

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -51,7 +51,9 @@ public class OAuthConfiguration implements WebMvcConfigurer {
     }
 
     public List<String> parseClassesNames() {
-        PackageScanner packageScanner = new PackageScanner(new SourceVisitor());
+        String startsWith = getClass().getCanonicalName().split("\\.")[0];
+
+        PackageScanner packageScanner = new PackageScanner(new SourceVisitor(startsWith));
         return packageScanner.getAllClassNames();
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/PackageScannerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/PackageScannerTest.java
@@ -28,7 +28,7 @@ class PackageScannerTest {
             .replace("/build/classes/java/test", "/src/test/java");
 
         Path rootPath = Path.of(new URI(resource));
-        PackageScanner packageScanner = new PackageScanner(rootPath, new TestSourceVisitor());
+        PackageScanner packageScanner = new PackageScanner(rootPath, new TestSourceVisitor("com"));
         List<String> allClassNames = packageScanner.getAllClassNames();
 
         assertThat(allClassNames)
@@ -41,6 +41,10 @@ class PackageScannerTest {
     }
 
     private static class TestSourceVisitor extends SourceVisitor {
+
+        public TestSourceVisitor(String startsWith) {
+            super(startsWith);
+        }
 
         public List<String> getClassPaths() {
             return super.getClassPaths();

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/SourceVisitorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/SourceVisitorTest.java
@@ -10,6 +10,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,8 @@ class SourceVisitorTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        sourceVisitor = new SourceVisitor();
+        String startsWith = getClass().getCanonicalName().split("\\.")[0];
+        sourceVisitor = new SourceVisitor(startsWith);
     }
 
     @DisplayName("CONTINUE를 반환한다.")
@@ -44,9 +46,11 @@ class SourceVisitorTest {
 
     @DisplayName(".java 파일에서 package name을 추출한다.")
     @Test
-    void visitFile_javaFile() throws IOException {
-        Path file = createTempFile(".java");
-        String fileName = file.getFileName().toString().replace(".java", "");
+    void visitFile_javaFile() throws IOException, URISyntaxException {
+        String fileName = getClass().getSimpleName();
+        String src =
+            Objects.requireNonNull(getClass().getResource(".")).toURI() + fileName + ".class";
+        Path file = Path.of(new URI(src));
 
         FileVisitResult actual = sourceVisitor.visitFile(file, null);
         List<String> classPaths = sourceVisitor.getClassPaths();


### PR DESCRIPTION
## 상세 내용

.java 파일 기준으로 className과 package location을 파싱하였으나 jar에 java파일이 존재하지 않아 버그.
package 폴더 구조를 기반으로 파싱하는 방법으로 변경,.

<br/>

## 기타

<br/>

Close #{이슈_번호}
