### PR TITLE
[#451] classname 파싱 버그를 해결한다.

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/OAuthConfiguration.java
@@ -53,7 +53,8 @@ public class OAuthConfiguration implements WebMvcConfigurer {
     public List<String> parseClassesNames() {
         String startsWith = getClass().getCanonicalName().split("\\.")[0];
 
-        PackageScanner packageScanner = new PackageScanner(new SourceVisitor(startsWith));
+        PackageScanner packageScanner =
+            new PackageScanner("com.woowacourse.pickgit", new SourceVisitor(startsWith));
         return packageScanner.getAllClassNames();
     }
 
@@ -79,11 +80,11 @@ public class OAuthConfiguration implements WebMvcConfigurer {
 
         AutoAuthorizationInterceptorRegister autoAuthorizationInterceptorRegister =
             AutoAuthorizationInterceptorRegister.builder()
-            .storageForRegisterTypes(getStorageForRegisterTypes())
-            .authenticationInterceptor(authenticationInterceptor)
-            .ignoreAuthenticationInterceptor(ignoreAuthenticationInterceptor)
-            .uriParser(getUriParser())
-            .build();
+                .storageForRegisterTypes(getStorageForRegisterTypes())
+                .authenticationInterceptor(authenticationInterceptor)
+                .ignoreAuthenticationInterceptor(ignoreAuthenticationInterceptor)
+                .uriParser(getUriParser())
+                .build();
 
         autoAuthorizationInterceptorRegister.execute();
         ignoreAuthenticationInterceptor

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/PackageScanner.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/PackageScanner.java
@@ -33,7 +33,7 @@ public class PackageScanner {
             URI baseUri = Objects.requireNonNull(ClassLoader.getSystemResource(".")).toURI();
             String stringBaseUri = baseUri.normalize().getPath();
 
-            stringBaseUri = stringBaseUri.replaceAll("\\/test\\/", "/production/");
+            stringBaseUri = stringBaseUri.replaceAll("\\/test\\/", "/main/");
             String uri = basePackage.replaceAll("[.]", "/");
 
             return new File(stringBaseUri + uri).toPath();

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/PackageScanner.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/PackageScanner.java
@@ -1,35 +1,44 @@
 package com.woowacourse.pickgit.config.auth_interceptor_register.scanner.package_scanner;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 
 public class PackageScanner {
 
-    private final Path rootPath;
+    private final String basePackage;
     private final SourceVisitor sourceVisitor;
 
-    public PackageScanner(SourceVisitor sourceVisitor) {
-        this(
-            Paths.get(".").normalize().toAbsolutePath(),
-            sourceVisitor
-        );
-    }
-
-    public PackageScanner(Path rootPath, SourceVisitor sourceVisitor) {
-        this.rootPath = rootPath;
+    public PackageScanner(String basePackage, SourceVisitor sourceVisitor) {
+        this.basePackage = basePackage;
         this.sourceVisitor = sourceVisitor;
     }
 
     public List<String> getAllClassNames() {
         try {
-            Files.walkFileTree(rootPath, sourceVisitor);
+            Files.walkFileTree(getBaseUri(), sourceVisitor);
             return sourceVisitor.getClassPaths();
         } catch (IOException e) {
             throw new IllegalArgumentException("Interceptor register: 파일 순회 오류", e);
         }
     }
 
+    private Path getBaseUri() {
+        try {
+            URI baseUri = Objects.requireNonNull(ClassLoader.getSystemResource(".")).toURI();
+            String stringBaseUri = baseUri.normalize().getPath();
+
+            stringBaseUri = stringBaseUri.replaceAll("\\/test\\/", "/production/");
+            String uri = basePackage.replaceAll("[.]", "/");
+
+            return new File(stringBaseUri + uri).toPath();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/SourceVisitor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/package_scanner/SourceVisitor.java
@@ -10,15 +10,15 @@ import java.util.List;
 
 public class SourceVisitor implements FileVisitor<Path> {
 
-    private final String startsWith;
+    private final String basePackage;
     private final List<String> classPaths;
 
-    public SourceVisitor(String startsWith) {
-        this(startsWith, new ArrayList<>());
+    public SourceVisitor(String basePackage) {
+        this(basePackage, new ArrayList<>());
     }
 
-    public SourceVisitor(String startsWith, List<String> classPaths) {
-        this.startsWith = startsWith;
+    public SourceVisitor(String basePackage, List<String> classPaths) {
+        this.basePackage = basePackage;
         this.classPaths = classPaths;
     }
 
@@ -30,9 +30,6 @@ public class SourceVisitor implements FileVisitor<Path> {
     public FileVisitResult preVisitDirectory(
         Path dir, BasicFileAttributes attrs
     ) throws IOException {
-        if (dir.getFileName().toString().contains("test")) {
-            return FileVisitResult.SKIP_SUBTREE;
-        }
         return FileVisitResult.CONTINUE;
     }
 
@@ -43,7 +40,7 @@ public class SourceVisitor implements FileVisitor<Path> {
         }
 
         String classSource = file.toUri().toString();
-        int index = classSource.indexOf(startsWith);
+        int index = classSource.indexOf(basePackage);
         if (index == -1) {
             return FileVisitResult.CONTINUE;
         }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/PackageScannerTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/PackageScannerTest.java
@@ -20,21 +20,16 @@ import org.junit.jupiter.api.Test;
 
 class PackageScannerTest {
 
-    @DisplayName("루트 폴더 내부를 순회하며 Controller class파일의 이름을 추출한다.")
+    @DisplayName("루트 폴더 내부를 순회하며 class파일의 이름을 추출한다.")
     @Test
     void getAllClassNames_extractControllerJavaFilesName_Success() throws URISyntaxException {
-        String resource = ClassOne.class.getResource(".").toString();
-
-        Path rootPath = Path.of(new URI(resource));
-        PackageScanner packageScanner = new PackageScanner(rootPath, new TestSourceVisitor("com"));
+        PackageScanner packageScanner =
+            new PackageScanner("com.woowacourse.pickgit", new TestSourceVisitor("com"));
         List<String> allClassNames = packageScanner.getAllClassNames();
 
-        assertThat(allClassNames)
-            .contains(
-                ClassOne.class.getCanonicalName(),
-                ClassTwo.class.getCanonicalName(),
-                ClassThree.class.getCanonicalName(),
-                ClassFour.class.getCanonicalName()
+        assertThat(allClassNames).isNotEmpty();
+        assertThat(allClassNames).contains(
+                "com.woowacourse.pickgit.PickGitApplication"
             );
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/SourceVisitorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/auth_interceptor_register/scanner/SourceVisitorTest.java
@@ -34,19 +34,9 @@ class SourceVisitorTest {
         assertThat(actual).isEqualTo(FileVisitResult.CONTINUE);
     }
 
-    @DisplayName("test 폴더인 경우 무시하고 탐색한다.")
+    @DisplayName("package name을 추출한다.")
     @Test
-    void preVisitDirectory_testDirectory() throws IOException, URISyntaxException {
-        String uri = getClass().getResource(".").toURI().toASCIIString();
-        Path file = Path.of(new URI(uri.substring(0, uri.indexOf("test") + 4)));
-        FileVisitResult actual = sourceVisitor.preVisitDirectory(file, null);
-
-        assertThat(actual).isEqualTo(FileVisitResult.SKIP_SUBTREE);
-    }
-
-    @DisplayName(".java 파일에서 package name을 추출한다.")
-    @Test
-    void visitFile_javaFile() throws IOException, URISyntaxException {
+    void visitFile_pakcageName() throws IOException, URISyntaxException {
         String fileName = getClass().getSimpleName();
         String src =
             Objects.requireNonNull(getClass().getResource(".")).toURI() + fileName + ".class";
@@ -61,7 +51,7 @@ class SourceVisitorTest {
         );
     }
 
-    @DisplayName(".java 파일이 아니라면 무시한다")
+    @DisplayName(".class 파일이 아니라면 무시한다")
     @Test
     void visitFile_otherFiles() throws IOException {
         Path file = createTempFile(".tmp");


### PR DESCRIPTION
## 상세 내용

파일 탐색 위치가, ClassLoader 기준이 아닌, jar기준으로 되어있어 발생한 버그.
<br/>

## 기타

<br/>

Close #451
