### PR TITLE
[#521] 포트폴리오 기능 버그 해결

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/repository/PortfolioRepository.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/repository/PortfolioRepository.java
@@ -4,9 +4,10 @@ import com.woowacourse.pickgit.portfolio.domain.Portfolio;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
 
-    @Query("select Portfolio from Portfolio p where p.user.basicProfile.name = :username")
-    Optional<Portfolio> findPortfolioByUsername(String username);
+    @Query("select p from Portfolio p where p.user.basicProfile.name = :username")
+    Optional<Portfolio> findPortfolioByUsername(@Param("username") String username);
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/presentation/PortfolioController.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/presentation/PortfolioController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/portfolio")
+@RequestMapping("/api/portfolios")
 @CrossOrigin(value = "*")
 public class PortfolioController {
 


### PR DESCRIPTION
## 상세 내용
- JPQL 문법을 수정했습니다.
```java
// 전
@Query("select Portfolio from Portfolio p where p.user.basicProfile.name = :username")
Optional<Portfolio> findPortfolioByUsername(@Param("username") String username);

// 후
@Query("select p from Portfolio p where p.user.basicProfile.name = :username")
Optional<Portfolio> findPortfolioByUsername(@Param("username") String username);
```

- API URI를 수정했습니다.
```java
// 전
@RestController
@RequestMapping("/api/portfolio")
@CrossOrigin(value = "*")
public class PortfolioController {

// 후
@RestController
@RequestMapping("/api/portfolios")
@CrossOrigin(value = "*")
public class PortfolioController {
```

<br/>

Close #521 