### PR TITLE
[#529] API URL을 Property 상수로 관리

### DIFF
--- a/backend/pick-git/build.gradle
+++ b/backend/pick-git/build.gradle
@@ -113,7 +113,8 @@ jacocoTestReport {
                             '**/*S3*',
                             '**/*DataSource*',
                             '**/*Slave*',
-                            '**/portfolio*'
+                            '**/portfolio*',
+                            '**/*UpdateUtil*'
                     ])
         }))
     }
@@ -153,7 +154,8 @@ jacocoTestCoverageVerification {
                     '**.*Project*',
                     '**.*Section*',
                     '**.*Description*',
-                    '**.*Item*'
+                    '**.*Item*',
+                    '**.*UpdateUtil*'
             ]
         }
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/GithubOAuthClient.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/GithubOAuthClient.java
@@ -34,13 +34,15 @@ public class GithubOAuthClient implements OAuthClient {
     @Value("${security.github.url.access-token}")
     private String accessTokenUrl;
 
+    @Value("${security.github.url.oauth-login-format")
+    private String oauthLoginUrlFormat;
+
+    @Value("${security.github.url.user-profile}")
+    private String githubProfileUrl;
+
     @Override
     public String getLoginUrl() {
-        return String.format("https://github.com/login/oauth/authorize"
-                + "?client_id=%s"
-                + "&redirect_uri=%s"
-                + "&scope=%s",
-            clientId, redirectUrl, scope);
+        return String.format(oauthLoginUrlFormat, clientId, redirectUrl, scope);
     }
 
     @Override
@@ -73,7 +75,7 @@ public class GithubOAuthClient implements OAuthClient {
 
         RestTemplate restTemplate = new RestTemplate();
         return restTemplate
-            .exchange("https://api.github.com/user", HttpMethod.GET, httpEntity, OAuthProfileResponse.class)
+            .exchange(githubProfileUrl, HttpMethod.GET, httpEntity, OAuthProfileResponse.class)
             .getBody();
     }
 }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositoryExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositoryExtractor.java
@@ -8,23 +8,25 @@ import com.woowacourse.pickgit.post.domain.util.PlatformRepositoryApiRequester;
 import com.woowacourse.pickgit.post.domain.util.PlatformRepositoryExtractor;
 import com.woowacourse.pickgit.post.domain.util.dto.RepositoryNameAndUrl;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GithubRepositoryExtractor implements PlatformRepositoryExtractor {
 
-    private static final String API_URL_FORMAT = "https://api.github.com/users/%s/repos?page=%d&per_page=%d";
-
     private final ObjectMapper objectMapper;
     private final PlatformRepositoryApiRequester platformRepositoryApiRequester;
+    private final String apiUrlFormatForRepository;
 
     public GithubRepositoryExtractor(
         ObjectMapper objectMapper,
-        PlatformRepositoryApiRequester platformRepositoryApiRequester
+        PlatformRepositoryApiRequester platformRepositoryApiRequester,
+        @Value("${github.repository.format-url}") String apiUrlFormatForRepository
     ) {
         this.objectMapper = objectMapper;
         this.platformRepositoryApiRequester = platformRepositoryApiRequester;
+        this.apiUrlFormatForRepository = apiUrlFormatForRepository;
     }
 
     @Override
@@ -37,7 +39,7 @@ public class GithubRepositoryExtractor implements PlatformRepositoryExtractor {
 
     private String generateApiUrl(String username, Pageable pageable) {
         return String
-            .format(API_URL_FORMAT, username, pageable.getPageNumber() + 1, pageable.getPageSize());
+            .format(apiUrlFormatForRepository, username, pageable.getPageNumber() + 1, pageable.getPageSize());
     }
 
     private List<RepositoryNameAndUrl> parseToRepositories(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositoryExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositoryExtractor.java
@@ -17,16 +17,16 @@ public class GithubRepositoryExtractor implements PlatformRepositoryExtractor {
 
     private final ObjectMapper objectMapper;
     private final PlatformRepositoryApiRequester platformRepositoryApiRequester;
-    private final String apiUrlFormatForRepository;
+    private final String apiBaseUrl;
 
     public GithubRepositoryExtractor(
         ObjectMapper objectMapper,
         PlatformRepositoryApiRequester platformRepositoryApiRequester,
-        @Value("${github.repository.format-url}") String apiUrlFormatForRepository
+        @Value("${security.github.url.api}") String apiBaseUrl
     ) {
         this.objectMapper = objectMapper;
         this.platformRepositoryApiRequester = platformRepositoryApiRequester;
-        this.apiUrlFormatForRepository = apiUrlFormatForRepository;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     @Override
@@ -38,8 +38,8 @@ public class GithubRepositoryExtractor implements PlatformRepositoryExtractor {
     }
 
     private String generateApiUrl(String username, Pageable pageable) {
-        return String
-            .format(apiUrlFormatForRepository, username, pageable.getPageNumber() + 1, pageable.getPageSize());
+        String format = apiBaseUrl + "/users/%s/repos?page=%d&per_page=%d";
+        return String.format(format, username, pageable.getPageNumber() + 1, pageable.getPageSize());
     }
 
     private List<RepositoryNameAndUrl> parseToRepositories(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
@@ -17,16 +17,16 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
 
     private final ObjectMapper objectMapper;
     private final PlatformRepositoryApiRequester platformRepositoryApiRequester;
-    private final String apiUrlFormatForSearchRepository;
+    private final String apiBaseUrl;
 
     public GithubRepositorySearchExtractor(
         ObjectMapper objectMapper,
         PlatformRepositoryApiRequester platformRepositoryApiRequester,
-        @Value("${github.repository.search.format-url}") String apiUrlFormatForSearchRepository
+        @Value("${security.github.url.api}") String apiBaseUrl
     ) {
         this.objectMapper = objectMapper;
         this.platformRepositoryApiRequester = platformRepositoryApiRequester;
-        this.apiUrlFormatForSearchRepository = apiUrlFormatForSearchRepository;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     @Override
@@ -52,9 +52,10 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
         int page,
         int limit
     ) {
-
+        String format = apiBaseUrl +
+            "/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d";
         return String.format(
-            apiUrlFormatForSearchRepository,
+            format,
             username,
             keyword,
             page,

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
@@ -54,13 +54,7 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
     ) {
         String format = apiBaseUrl +
             "/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d";
-        return String.format(
-            format,
-            username,
-            keyword,
-            page,
-            limit
-        );
+        return String.format(format, username, keyword, page, limit);
     }
 
     private RepositoryItemDto parseToRepositories(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/post/infrastructure/extractor/GithubRepositorySearchExtractor.java
@@ -9,24 +9,24 @@ import com.woowacourse.pickgit.post.domain.util.PlatformRepositorySearchExtracto
 import com.woowacourse.pickgit.post.domain.util.dto.RepositoryNameAndUrl;
 import com.woowacourse.pickgit.post.infrastructure.dto.RepositoryItemDto;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GithubRepositorySearchExtractor implements PlatformRepositorySearchExtractor {
 
-    private static final String API_URL_FORMAT =
-        "https://api.github.com/search/repositories?"
-            + "q=user:%s %s in:name fork:true&page=%d&per_page=%d";
-
     private final ObjectMapper objectMapper;
     private final PlatformRepositoryApiRequester platformRepositoryApiRequester;
+    private final String apiUrlFormatForSearchRepository;
 
     public GithubRepositorySearchExtractor(
         ObjectMapper objectMapper,
-        PlatformRepositoryApiRequester platformRepositoryApiRequester
+        PlatformRepositoryApiRequester platformRepositoryApiRequester,
+        @Value("${github.repository.search.format-url}") String apiUrlFormatForSearchRepository
     ) {
         this.objectMapper = objectMapper;
         this.platformRepositoryApiRequester = platformRepositoryApiRequester;
+        this.apiUrlFormatForSearchRepository = apiUrlFormatForSearchRepository;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class GithubRepositorySearchExtractor implements PlatformRepositorySearch
     ) {
 
         return String.format(
-            API_URL_FORMAT,
+            apiUrlFormatForSearchRepository,
             username,
             keyword,
             page,

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/tag/infrastructure/GithubTagExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/tag/infrastructure/GithubTagExtractor.java
@@ -9,22 +9,26 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GithubTagExtractor implements PlatformTagExtractor {
 
-    private static final String GITHUB_TAG_API_FORMAT
-        = "https://api.github.com/repos/%s/%s/languages";
     private static final String OTHER_TAG = "Other";
 
     private final PlatformTagApiRequester platformTagApiRequester;
     private final ObjectMapper objectMapper;
+    private final String apiUrlFormatForTag;
 
-    public GithubTagExtractor(PlatformTagApiRequester platformTagApiRequester,
-        ObjectMapper objectMapper) {
+    public GithubTagExtractor(
+        PlatformTagApiRequester platformTagApiRequester,
+        ObjectMapper objectMapper,
+        @Value("${github.tag.format-url}") String apiUrlFormatForTag
+    ) {
         this.platformTagApiRequester = platformTagApiRequester;
         this.objectMapper = objectMapper;
+        this.apiUrlFormatForTag = apiUrlFormatForTag;
     }
 
     public List<String> extractTags(String accessToken, String userName, String repositoryName) {
@@ -34,7 +38,7 @@ public class GithubTagExtractor implements PlatformTagExtractor {
     }
 
     private String generateApiUrl(String userName, String repositoryName) {
-        return String.format(GITHUB_TAG_API_FORMAT, userName, repositoryName);
+        return String.format(apiUrlFormatForTag, userName, repositoryName);
     }
 
     private List<String> parseResponseIntoLanguageTags(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/tag/infrastructure/GithubTagExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/tag/infrastructure/GithubTagExtractor.java
@@ -19,16 +19,16 @@ public class GithubTagExtractor implements PlatformTagExtractor {
 
     private final PlatformTagApiRequester platformTagApiRequester;
     private final ObjectMapper objectMapper;
-    private final String apiUrlFormatForTag;
+    private final String apiBaseUrl;
 
     public GithubTagExtractor(
         PlatformTagApiRequester platformTagApiRequester,
         ObjectMapper objectMapper,
-        @Value("${github.tag.format-url}") String apiUrlFormatForTag
+        @Value("${security.github.url.api}") String apiBaseUrl
     ) {
         this.platformTagApiRequester = platformTagApiRequester;
         this.objectMapper = objectMapper;
-        this.apiUrlFormatForTag = apiUrlFormatForTag;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     public List<String> extractTags(String accessToken, String userName, String repositoryName) {
@@ -38,7 +38,8 @@ public class GithubTagExtractor implements PlatformTagExtractor {
     }
 
     private String generateApiUrl(String userName, String repositoryName) {
-        return String.format(apiUrlFormatForTag, userName, repositoryName);
+        String url = apiBaseUrl + "/repos/%s/%s/languages";
+        return String.format(url, userName, repositoryName);
     }
 
     private List<String> parseResponseIntoLanguageTags(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/calculator/GithubContributionCalculator.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/calculator/GithubContributionCalculator.java
@@ -41,28 +41,28 @@ public class GithubContributionCalculator implements PlatformContributionCalcula
 
     private int calculateCommits(String accessToken, String username) {
         CountDto count = platformContributionExtractor
-            .extractCount("/commits?q=committer:%s", accessToken, username);
+            .extractCount("/search/commits?q=committer:%s", accessToken, username);
 
         return count.getCount();
     }
 
     private int calculatePRs(String accessToken, String username) {
         CountDto count = platformContributionExtractor
-            .extractCount("/issues?q=author:%s type:pr", accessToken, username);
+            .extractCount("/search/issues?q=author:%s type:pr", accessToken, username);
 
         return count.getCount();
     }
 
     private int calculateIssues(String accessToken, String username) {
         CountDto count = platformContributionExtractor
-            .extractCount("/issues?q=author:%s type:issue", accessToken, username);
+            .extractCount("/search/issues?q=author:%s type:issue", accessToken, username);
 
         return count.getCount();
     }
 
     private int calculateRepos(String accessToken, String username) {
         CountDto count = platformContributionExtractor
-            .extractCount("/repositories?q=user:%s is:public", accessToken, username);
+            .extractCount("/search/repositories?q=user:%s is:public", accessToken, username);
 
         return count.getCount();
     }

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/extractor/GithubContributionExtractor.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/extractor/GithubContributionExtractor.java
@@ -15,19 +15,16 @@ public class GithubContributionExtractor implements PlatformContributionExtracto
 
     private final ObjectMapper objectMapper;
     private final PlatformContributionApiRequester platformContributionApiRequester;
-    private final String apiUrlFormatForStar;
-    private final String apiUrlFormatForCount;
+    private final String apiBaseUrl;
 
     public GithubContributionExtractor(
         ObjectMapper objectMapper,
         PlatformContributionApiRequester platformContributionApiRequester,
-        @Value("${github.contribution.star-url}") String apiUrlFormatForStar,
-        @Value("${github.contribution.count-url}") String apiUrlFormatForCount
+        @Value("${security.github.url.api}") String apiBaseUrl
     ) {
         this.objectMapper = objectMapper;
         this.platformContributionApiRequester = platformContributionApiRequester;
-        this.apiUrlFormatForStar = apiUrlFormatForStar;
-        this.apiUrlFormatForCount = apiUrlFormatForCount;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     @Override
@@ -39,7 +36,8 @@ public class GithubContributionExtractor implements PlatformContributionExtracto
     }
 
     private String generateUrl(String username) {
-        return String.format(apiUrlFormatForStar, username);
+        String url = apiBaseUrl + "/search/repositories?q=user:%s stars:>=1";
+        return String.format(url, username);
     }
 
     private ItemDto parseToStars(String response) {
@@ -59,7 +57,7 @@ public class GithubContributionExtractor implements PlatformContributionExtracto
     }
 
     private String generateUrl(String restUrl, String username) {
-        return apiUrlFormatForCount + String.format(restUrl, username);
+        return apiBaseUrl + String.format(restUrl, username);
     }
 
     private CountDto parseToCount(String response) {

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/requester/GithubFollowingRequester.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/requester/GithubFollowingRequester.java
@@ -15,12 +15,12 @@ import org.springframework.web.client.RestTemplate;
 @Profile("!test")
 public class GithubFollowingRequester implements PlatformFollowingRequester {
 
-    private final String apiUrlFormatForFollowing;
+    private final String apiBaseUrl;
 
     public GithubFollowingRequester(
-        @Value("${github.follow.format-url") String apiUrlFormatForFollowing
+        @Value("${security.github.url.api}") String apiBaseUrl
     ) {
-        this.apiUrlFormatForFollowing = apiUrlFormatForFollowing;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     @Override
@@ -34,7 +34,8 @@ public class GithubFollowingRequester implements PlatformFollowingRequester {
     }
 
     private void requestFollowingOrUnFollowing(HttpMethod method, String targetName, String accessToken) {
-        String url = String.format(apiUrlFormatForFollowing, targetName);
+        String format = apiBaseUrl + "/user/following/%s";
+        String url = String.format(format, targetName);
         try {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setBearerAuth(accessToken);

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/requester/GithubFollowingRequester.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/user/infrastructure/requester/GithubFollowingRequester.java
@@ -2,6 +2,7 @@ package com.woowacourse.pickgit.user.infrastructure.requester;
 
 import com.woowacourse.pickgit.exception.platform.PlatformHttpErrorException;
 import com.woowacourse.pickgit.user.domain.follow.PlatformFollowingRequester;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -13,7 +14,14 @@ import org.springframework.web.client.RestTemplate;
 @Component
 @Profile("!test")
 public class GithubFollowingRequester implements PlatformFollowingRequester {
-    private static final String URL_FORMAT = "https://api.github.com/user/following/%s";
+
+    private final String apiUrlFormatForFollowing;
+
+    public GithubFollowingRequester(
+        @Value("${github.follow.format-url") String apiUrlFormatForFollowing
+    ) {
+        this.apiUrlFormatForFollowing = apiUrlFormatForFollowing;
+    }
 
     @Override
     public void follow(String targetName, String accessToken) {
@@ -26,7 +34,7 @@ public class GithubFollowingRequester implements PlatformFollowingRequester {
     }
 
     private void requestFollowingOrUnFollowing(HttpMethod method, String targetName, String accessToken) {
-        String url = String.format(URL_FORMAT, targetName);
+        String url = String.format(apiUrlFormatForFollowing, targetName);
         try {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setBearerAuth(accessToken);

--- a/backend/pick-git/src/main/resources/application.yml
+++ b/backend/pick-git/src/main/resources/application.yml
@@ -3,16 +3,3 @@ spring:
     include: security, db
   flyway:
     enabled: false
-
-github:
-  contribution:
-    star-url: https://api.github.com/search/repositories?q=user:%s stars:>=1
-    count-url: https://api.github.com/search/
-  tag:
-    format-url: https://api.github.com/repos/%s/%s/languages
-  repository:
-    format-url: https://api.github.com/users/%s/repos?page=%d&per_page=%d
-    search:
-      format-url: https://api.github.com/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d
-  follow:
-    format-url: https://api.github.com/user/following/%s

--- a/backend/pick-git/src/main/resources/application.yml
+++ b/backend/pick-git/src/main/resources/application.yml
@@ -8,3 +8,11 @@ github:
   contribution:
     star-url: https://api.github.com/search/repositories?q=user:%s stars:>=1
     count-url: https://api.github.com/search/
+  tag:
+    format-url: https://api.github.com/repos/%s/%s/languages
+  repository:
+    format-url: https://api.github.com/users/%s/repos?page=%d&per_page=%d
+    search:
+      format-url: https://api.github.com/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d
+  follow:
+    format-url: https://api.github.com/user/following/%s

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/tag/TagServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/tag/TagServiceIntegrationTest.java
@@ -48,7 +48,7 @@ class TagServiceIntegrationTest {
             new GithubTagExtractor(
                 new MockTagApiRequester(),
                 objectMapper,
-                "https://api.github.com/repos/%s/%s/languages"
+                "https://api.github.com"
             );
         tagService = new TagService(platformTagExtractor, tagRepository);
     }

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/tag/TagServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/tag/TagServiceIntegrationTest.java
@@ -45,7 +45,11 @@ class TagServiceIntegrationTest {
     @BeforeEach
     void setUp() {
         PlatformTagExtractor platformTagExtractor =
-            new GithubTagExtractor(new MockTagApiRequester(), objectMapper);
+            new GithubTagExtractor(
+                new MockTagApiRequester(),
+                objectMapper,
+                "https://api.github.com/repos/%s/%s/languages"
+            );
         tagService = new TagService(platformTagExtractor, tagRepository);
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositoryExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositoryExtractorTest.java
@@ -32,7 +32,7 @@ class GithubRepositoryExtractorTest {
         platformRepositoryExtractor = new GithubRepositoryExtractor(
             objectMapper,
             new MockRepositoryApiRequester(),
-            "https://api.github.com/users/%s/repos?page=%d&per_page=%d"
+            "https://api.github.com"
         );
     }
 
@@ -61,7 +61,7 @@ class GithubRepositoryExtractorTest {
         platformRepositoryExtractor = new GithubRepositoryExtractor(
             objectMapper,
             new MockEmptyRepositoryApiRequester(),
-            "https://api.github.com/users/%s/repos?page=%d&per_page=%d"
+            "https://api.github.com"
         );
 
         // when

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositoryExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositoryExtractorTest.java
@@ -29,8 +29,11 @@ class GithubRepositoryExtractorTest {
 
     @BeforeEach
     void setUp() {
-        platformRepositoryExtractor =
-            new GithubRepositoryExtractor(objectMapper, new MockRepositoryApiRequester());
+        platformRepositoryExtractor = new GithubRepositoryExtractor(
+            objectMapper,
+            new MockRepositoryApiRequester(),
+            "https://api.github.com/users/%s/repos?page=%d&per_page=%d"
+        );
     }
 
     @DisplayName("요청 페이지에 퍼블릭 레포지토리가 있는 경우 퍼블릭 레포지토리 목록을 반환한다.")
@@ -55,8 +58,11 @@ class GithubRepositoryExtractorTest {
         // given
         Pageable pageable = PageRequest.of(59, 50);
 
-        platformRepositoryExtractor =
-            new GithubRepositoryExtractor(objectMapper, new MockEmptyRepositoryApiRequester());
+        platformRepositoryExtractor = new GithubRepositoryExtractor(
+            objectMapper,
+            new MockEmptyRepositoryApiRequester(),
+            "https://api.github.com/users/%s/repos?page=%d&per_page=%d"
+        );
 
         // when
         List<RepositoryNameAndUrl> repositories = platformRepositoryExtractor

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
@@ -28,9 +28,10 @@ public class GithubRepositorySearchExtractorTest {
 
     @BeforeEach
     void setUp() {
-        this.platformRepositorySearchExtractor =
-            new GithubRepositorySearchExtractor(
-                objectMapper, new MockRepositoryApiRequester()
+        this.platformRepositorySearchExtractor = new GithubRepositorySearchExtractor(
+                objectMapper,
+                new MockRepositoryApiRequester(),
+            "https://api.github.com/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d"
             );
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/infrastructure/GithubRepositorySearchExtractorTest.java
@@ -31,7 +31,7 @@ public class GithubRepositorySearchExtractorTest {
         this.platformRepositorySearchExtractor = new GithubRepositorySearchExtractor(
                 objectMapper,
                 new MockRepositoryApiRequester(),
-            "https://api.github.com/search/repositories?q=user:%s %s in:name fork:true&page=%d&per_page=%d"
+            "https://api.github.com"
             );
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_searchPosts.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/post/presentation/PostFeedControllerTest_searchPosts.java
@@ -45,7 +45,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureRestDocs
 @WebMvcTest(PostFeedController.class)
-public class PostFeedControllerTest_searchPosts {
+class PostFeedControllerTest_searchPosts {
 
     private static final String API_ACCESS_TOKEN = "oauth.access.token";
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/tag/infrastructure/GithubTagExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/tag/infrastructure/GithubTagExtractorTest.java
@@ -26,7 +26,11 @@ class GithubTagExtractorTest {
     @BeforeEach
     void setUp() {
         PlatformTagApiRequester platformTagApiRequester = new MockTagApiRequester();
-        platformTagExtractor = new GithubTagExtractor(platformTagApiRequester, objectMapper);
+        platformTagExtractor = new GithubTagExtractor(
+            platformTagApiRequester,
+            objectMapper,
+            "https://api.github.com/repos/%s/%s/languages"
+        );
     }
 
     @DisplayName("명시된 User의 Repository에 기술된 Language Tags(Other 제외)를 추출한다.")

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/tag/infrastructure/GithubTagExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/tag/infrastructure/GithubTagExtractorTest.java
@@ -29,7 +29,7 @@ class GithubTagExtractorTest {
         platformTagExtractor = new GithubTagExtractor(
             platformTagApiRequester,
             objectMapper,
-            "https://api.github.com/repos/%s/%s/languages"
+            "https://api.github.com"
         );
     }
 

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/infrastructure/GithubContributionCalculatorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/infrastructure/GithubContributionCalculatorTest.java
@@ -36,8 +36,7 @@ class GithubContributionCalculatorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
         platformContributionCalculator = new GithubContributionCalculator(
             platformContributionExtractor
@@ -66,8 +65,7 @@ class GithubContributionCalculatorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockStarsContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
         platformContributionCalculator = new GithubContributionCalculator(
             platformContributionExtractor
@@ -89,8 +87,7 @@ class GithubContributionCalculatorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockStarsContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
         platformContributionCalculator = new GithubContributionCalculator(
             platformContributionExtractor
@@ -128,8 +125,7 @@ class GithubContributionCalculatorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockCountContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
         platformContributionCalculator = new GithubContributionCalculator(
             platformContributionExtractor
@@ -151,8 +147,7 @@ class GithubContributionCalculatorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockCountContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
         platformContributionCalculator = new GithubContributionCalculator(
             platformContributionExtractor

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/infrastructure/GithubContributionExtractorTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/unit/user/infrastructure/GithubContributionExtractorTest.java
@@ -35,8 +35,7 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
     }
 
@@ -61,8 +60,7 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
@@ -81,8 +79,7 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
@@ -99,7 +96,7 @@ class GithubContributionExtractorTest {
     void extractCount_Commits_Success() {
         // when
         CountDto commits = platformContributionExtractor
-            .extractCount("/commits?q=committer:%s", ACCESS_TOKEN, USERNAME);
+            .extractCount("/search/commits?q=committer:%s", ACCESS_TOKEN, USERNAME);
 
         // then
         assertThat(commits.getCount()).isEqualTo(48);
@@ -112,14 +109,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/commits?q=committer:%s", INVALID_ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/commits?q=committer:%s", INVALID_ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(PlatformHttpErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -133,14 +129,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/commits?q=committer:%s", ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/commits?q=committer:%s", ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(ContributionParseException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -152,7 +147,7 @@ class GithubContributionExtractorTest {
     void extractCount_PRs_Success() {
         // when
         CountDto prs = platformContributionExtractor
-            .extractCount("/issues?q=author:%s type:pr", ACCESS_TOKEN, USERNAME);
+            .extractCount("/search/issues?q=author:%s type:pr", ACCESS_TOKEN, USERNAME);
 
         // then
         assertThat(prs.getCount()).isEqualTo(48);
@@ -165,14 +160,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/issues?q=author:%s type:pr", INVALID_ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/issues?q=author:%s type:pr", INVALID_ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(PlatformHttpErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -186,14 +180,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/issues?q=author:%s type:pr", ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/issues?q=author:%s type:pr", ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(ContributionParseException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -205,7 +198,7 @@ class GithubContributionExtractorTest {
     void extractCount_Issues_Success() {
         // when
         CountDto issues = platformContributionExtractor
-            .extractCount("/issues?q=author:%s type:issue", ACCESS_TOKEN, USERNAME);
+            .extractCount("/search/issues?q=author:%s type:issue", ACCESS_TOKEN, USERNAME);
 
         // then
         assertThat(issues.getCount()).isEqualTo(48);
@@ -218,14 +211,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/issues?q=author:%s type:issue", INVALID_ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/issues?q=author:%s type:issue", INVALID_ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(PlatformHttpErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -239,14 +231,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/issues?q=author:%s type:issue", ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/issues?q=author:%s type:issue", ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(ContributionParseException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -258,7 +249,7 @@ class GithubContributionExtractorTest {
     void extractCount_Repos_Success() {
         // when
         CountDto repos = platformContributionExtractor
-            .extractCount("/repositories?q=user:%s is:public", ACCESS_TOKEN, USERNAME);
+            .extractCount("/search/repositories?q=user:%s is:public", ACCESS_TOKEN, USERNAME);
 
         // then
         assertThat(repos.getCount()).isEqualTo(48);
@@ -271,14 +262,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/repositories?q=user:%s is:public", INVALID_ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/repositories?q=user:%s is:public", INVALID_ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(PlatformHttpErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -292,14 +282,13 @@ class GithubContributionExtractorTest {
         platformContributionExtractor = new GithubContributionExtractor(
             objectMapper,
             new MockContributionApiErrorRequester(),
-            apiUrlFormatForStar,
-            apiUrlFormatForCount
+            "https://api.github.com"
         );
 
         // when
         assertThatThrownBy(() -> {
             platformContributionExtractor
-                .extractCount("/repositories?q=user:%s is:public", ACCESS_TOKEN, USERNAME);
+                .extractCount("/search/repositories?q=user:%s is:public", ACCESS_TOKEN, USERNAME);
         }).isInstanceOf(ContributionParseException.class)
             .hasFieldOrPropertyWithValue("errorCode", "V0001")
             .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## 상세 내용

* 현재 깃헙으로 api 요청을 보내는 url이 클래스 내부 상수로 관리되고 있습니다.
* 성능 테스트를 하는 경우, 이러한 외부 연동 모듈 서비스는 인터페이스로 mocking하지 않고 별도의 외부 mock 서버를 띄우는 것을 권장하고 있습니다.
* 이를 위해 staging profile에서 url을 바꿔칠 수 있도록 관련 api url을 상수로 관리합니다.
   * oauth 관련 상수는 security에 정의합니다.

<br/>

## 기타

<br/>

Close #529
