### PR TITLE
[#563] 외부 Redis 토큰 저장소 기능을 구현

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/dao/CollectionOAuthAccessTokenDao.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/dao/CollectionOAuthAccessTokenDao.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-@Component
 public class CollectionOAuthAccessTokenDao implements OAuthAccessTokenDao {
 
     private final ConcurrentHashMap<String, String> tokenDB;

--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/dao/RedisOAuthAccessTokenDao.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/authentication/infrastructure/dao/RedisOAuthAccessTokenDao.java
@@ -1,0 +1,27 @@
+package com.woowacourse.pickgit.authentication.infrastructure.dao;
+
+import com.woowacourse.pickgit.authentication.domain.OAuthAccessTokenDao;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisOAuthAccessTokenDao implements OAuthAccessTokenDao {
+
+    private final ValueOperations<String, String> opsForValue;
+
+    public RedisOAuthAccessTokenDao(StringRedisTemplate redisTemplate) {
+        this.opsForValue = redisTemplate.opsForValue();
+    }
+
+    @Override
+    public void insert(String token, String oauthAccessToken) {
+        opsForValue.set(token, oauthAccessToken);
+    }
+
+    @Override
+    public Optional<String> findByKeyToken(String token) {
+        return Optional.ofNullable(opsForValue.get(token));
+    }
+}

--- a/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
+++ b/backend/pick-git/src/test/java/com/woowacourse/pickgit/integration/authentication/OAuthServiceIntegrationTest.java
@@ -14,7 +14,7 @@ import com.woowacourse.pickgit.authentication.domain.user.AppUser;
 import com.woowacourse.pickgit.authentication.domain.user.GuestUser;
 import com.woowacourse.pickgit.authentication.domain.user.LoginUser;
 import com.woowacourse.pickgit.authentication.infrastructure.JwtTokenProviderImpl;
-import com.woowacourse.pickgit.authentication.infrastructure.dao.CollectionOAuthAccessTokenDao;
+import com.woowacourse.pickgit.authentication.infrastructure.dao.RedisOAuthAccessTokenDao;
 import com.woowacourse.pickgit.config.InfrastructureTestConfiguration;
 import com.woowacourse.pickgit.exception.authentication.InvalidTokenException;
 import com.woowacourse.pickgit.exception.authentication.UnauthorizedException;
@@ -25,12 +25,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @Import(InfrastructureTestConfiguration.class)
-@DataJpaTest
+@Transactional
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
 class OAuthServiceIntegrationTest {
 
@@ -42,6 +46,9 @@ class OAuthServiceIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
     private JwtTokenProvider jwtTokenProvider;
 
@@ -55,7 +62,7 @@ class OAuthServiceIntegrationTest {
             SECRET_KEY,
             EXPIRATION_TIME_IN_MILLISECONDS
         );
-        this.oAuthAccessTokenDao = new CollectionOAuthAccessTokenDao();
+        this.oAuthAccessTokenDao = new RedisOAuthAccessTokenDao(redisTemplate);
         this.oAuthService = new OAuthService(
             oAuthClient,
             jwtTokenProvider,


### PR DESCRIPTION
## 상세 내용
- 현재 HashMap으로 저장되는 토큰 저장소를 외부 Redis 토큰 저장소로 분리시키기위해 Redis 토큰 저장소 구현.

<br/>

## 기타
- 기존엔 Refresh Token로 구현하였지만, 프론트측에서의 변경이 많이 발생할 것으로 예상됩니다. 일정 산정을 정확히 해야할 듯 합니다.
- 또한, 아예 인증 서버로 분리시키도록 하는 것을 염두에 두고 있습니다. 추후 회의를 통해 결정하도록 할게요!

<br>

> Domain과 Infra 계층에서의 DIP로 인해 코드 변경 거의 없이 구현가능했네요! 굳굳~

<br/>

Close #563
