### PR TITLE
[#596] 홈피드 전체보기 및 팔로잉한 유저만 보기 탭 기능 추가

### DIFF
--- a/frontend/src/@types/index.ts
+++ b/frontend/src/@types/index.ts
@@ -75,6 +75,8 @@ export interface PostEditData {
   content: string;
 }
 
+export type FeedFilterOption = "followings" | "all";
+
 export interface GithubStats {
   starsCount: number;
   commitsCount: number;

--- a/frontend/src/components/@shared/Tabs/Tabs.style.ts
+++ b/frontend/src/components/@shared/Tabs/Tabs.style.ts
@@ -1,12 +1,15 @@
-import styled from "styled-components";
+import styled, { css, CSSProp } from "styled-components";
 import { TabIndicatorKind } from "../../../@types";
 import { Z_INDEX } from "../../../constants/layout";
 
-export const Container = styled.section`
-  width: 100%;
-  height: fit-content;
-  overflow-x: hidden;
-`;
+export const Container = styled.section<{ cssProp?: CSSProp }>(
+  ({ cssProp }) => css`
+    width: 100%;
+    height: fit-content;
+    overflow-x: hidden;
+    ${cssProp}
+  `
+);
 
 export const TabButtonWrapper = styled.div`
   display: flex;

--- a/frontend/src/components/@shared/Tabs/Tabs.tsx
+++ b/frontend/src/components/@shared/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { CSSProp } from "styled-components";
 
 import { TabIndicatorKind, TabItem } from "../../../@types";
 import { getTabTextColor } from "../../../utils/tabs";
@@ -9,6 +10,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   defaultTabIndex?: number;
   tabIndicatorColor?: string;
   tabIndicatorKind: TabIndicatorKind;
+  cssProp?: CSSProp;
 }
 
 const Tabs = ({ tabIndicatorKind, defaultTabIndex = 0, tabItems, tabIndicatorColor, ...props }: Props) => {

--- a/frontend/src/components/Feed/Feed.stories.tsx
+++ b/frontend/src/components/Feed/Feed.stories.tsx
@@ -11,14 +11,19 @@ export default {
 };
 
 const Template: Story = (args) => {
-  const { data: infinitePostsData, isLoading } = useHomeFeedPostsQuery();
+  const { data: infinitePostsData, isLoading } = useHomeFeedPostsQuery("all");
 
   if (isLoading || !infinitePostsData) {
     return <PageLoading />;
   }
 
   return (
-    <Feed {...args} infinitePostsData={infinitePostsData} queryKey={QUERY.GET_HOME_FEED_POSTS} isFetching={false} />
+    <Feed
+      {...args}
+      infinitePostsData={infinitePostsData}
+      queryKey={QUERY.GET_HOME_FEED_POSTS("all")}
+      isFetching={false}
+    />
   );
 };
 

--- a/frontend/src/constants/queries.ts
+++ b/frontend/src/constants/queries.ts
@@ -1,8 +1,17 @@
+import { FeedFilterOption } from "../@types";
+
 export const QUERY = {
   GET_PROFILE: "GET_SELF_PROFILE",
   GET_PROFILE_FOLLOWING: "GET_PROFILE_FOLLOWING",
   GET_PROFILE_FOLLOWER: "GET_PROFILE_FOLLOWER",
-  GET_HOME_FEED_POSTS: "GET_HOME_FEED_POSTS",
+  GET_HOME_FEED_POSTS: (feedFilterOption: FeedFilterOption) => {
+    const table: { [K in FeedFilterOption]: string } = {
+      all: "GET_HOME_FEED_All_POSTS",
+      followings: "GET_HOME_FEED_FOLLOWING_POSTS",
+    };
+
+    return table[feedFilterOption];
+  },
   GET_USER_FEED_POSTS: "GET_USER_FEED_POSTS",
   GET_SEARCH_USER_RESULT: "GET_SEARCH_USER_RESULT",
   GET_SEARCH_POST_RESULT: "GET_SEARCH_POST_RESULT",

--- a/frontend/src/hooks/service/useHomeFeed.ts
+++ b/frontend/src/hooks/service/useHomeFeed.ts
@@ -2,18 +2,31 @@ import axios from "axios";
 import { useContext, useEffect } from "react";
 import { useQueryClient } from "react-query";
 
-import { Post } from "../../@types";
 import { QUERY } from "../../constants/queries";
+
 import UserContext from "../../contexts/UserContext";
+
+import { useHomeFeedPostsQuery } from "../../services/queries";
+
 import { removeDuplicatedData } from "../../utils/data";
 import { handleHTTPError } from "../../utils/error";
 import { isHttpErrorStatus } from "../../utils/typeGuard";
-import { useHomeFeedPostsQuery } from "../../services/queries";
+
 import useFeedMutation from "./useFeedMutation";
 
-const useHomeFeed = () => {
+import type { Post, FeedFilterOption } from "../../@types";
+
+const useHomeFeed = (feedFilterOption: FeedFilterOption) => {
   const { logout } = useContext(UserContext);
-  const { data: infinitePostsData, isLoading, error, isError, isFetching, fetchNextPage } = useHomeFeedPostsQuery();
+  const {
+    data: infinitePostsData,
+    isLoading,
+    error,
+    isError,
+    isFetching,
+    fetchNextPage,
+    refetch,
+  } = useHomeFeedPostsQuery(feedFilterOption);
 
   // TODO : 그냥 QUERY 만 보내도 되는지 알아보기
   const { setPostsPages } = useFeedMutation([QUERY]);
@@ -33,7 +46,7 @@ const useHomeFeed = () => {
         handleHTTPError(status, {
           unauthorized: () => {
             logout();
-            queryClient.refetchQueries(QUERY.GET_HOME_FEED_POSTS, { active: true });
+            queryClient.refetchQueries(QUERY.GET_HOME_FEED_POSTS("all"), { active: true });
           },
         });
       }
@@ -58,7 +71,7 @@ const useHomeFeed = () => {
     handleError();
   }, [error]);
 
-  return { infinitePostsData, isLoading, isFetching, isError, handlePostsEndIntersect };
+  return { infinitePostsData, isLoading, isFetching, isError, handlePostsEndIntersect, refetch };
 };
 
 export default useHomeFeed;

--- a/frontend/src/pages/HomeFeedPage/HomeFeedPage.style.ts
+++ b/frontend/src/pages/HomeFeedPage/HomeFeedPage.style.ts
@@ -1,4 +1,24 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Page } from "../../components/@styled/layout";
+import { setMobileMediaQuery, setTabletMediaQuery } from "../../components/@styled/mediaQueries";
 
 export const Container = styled(Page)<React.CSSProperties>``;
+
+export const PostTabWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1.25rem;
+`;
+
+export const postTabCSS = css`
+  width: 40%;
+  min-width: 10.625rem;
+
+  ${setMobileMediaQuery`
+    font-size: 0.8rem;
+  `}
+
+  ${setTabletMediaQuery`
+    font-size:0.8rem;
+  `};
+`;

--- a/frontend/src/pages/HomeFeedPage/HomeFeedPage.tsx
+++ b/frontend/src/pages/HomeFeedPage/HomeFeedPage.tsx
@@ -1,17 +1,31 @@
+import { useEffect, useState } from "react";
+import { FeedFilterOption } from "../../@types";
+
 import PageLoadingWithLogo from "../../components/@layout/PageLoadingWithLogo/PageLoadingWithLogo";
 import InfiniteScrollContainer from "../../components/@shared/InfiniteScrollContainer/InfiniteScrollContainer";
 import PageError from "../../components/@shared/PageError/PageError";
+import Tabs from "../../components/@shared/Tabs/Tabs";
 import Feed from "../../components/Feed/Feed";
 
 import { QUERY } from "../../constants/queries";
+import useAuth from "../../hooks/common/useAuth";
 
 import useInfiniteImagePreloader from "../../hooks/common/useInfiniteImagePreloader";
 import useHomeFeed from "../../hooks/service/useHomeFeed";
 
-import { Container } from "./HomeFeedPage.style";
+import { Container, postTabCSS, PostTabWrapper } from "./HomeFeedPage.style";
 
 const HomeFeedPage = () => {
-  const { infinitePostsData, isLoading, isFetching, isError, handlePostsEndIntersect } = useHomeFeed();
+  const { isLoggedIn } = useAuth();
+  const [feedFilterOption, setFeedFilterOption] = useState<FeedFilterOption>(isLoggedIn ? "followings" : "all");
+  const feed = {
+    followings: useHomeFeed("followings"),
+    all: useHomeFeed("all"),
+  };
+
+  const { infinitePostsData, isLoading, isFetching, isError, handlePostsEndIntersect, refetch } =
+    feed[feedFilterOption];
+
   const infiniteImageUrls =
     infinitePostsData?.pages.map<string[]>((posts) =>
       posts.reduce<string[]>((acc, post) => [...acc, ...post.imageUrls], [])
@@ -19,10 +33,23 @@ const HomeFeedPage = () => {
   const { isFirstImagesLoading, isImagesFetching, activateImageFetchingState } =
     useInfiniteImagePreloader(infiniteImageUrls);
 
+  const tabList = [
+    { name: "Followings", onTabChange: () => setFeedFilterOption("followings") },
+    { name: "All", onTabChange: () => setFeedFilterOption("all") },
+  ];
+
   const handleIntersect = () => {
     handlePostsEndIntersect();
     activateImageFetchingState();
   };
+
+  useEffect(() => {
+    setFeedFilterOption(isLoggedIn ? "followings" : "all");
+  }, [isLoggedIn]);
+
+  useEffect(() => {
+    refetch();
+  }, [feedFilterOption, refetch]);
 
   if (isLoading || isFirstImagesLoading) {
     return <PageLoadingWithLogo />;
@@ -34,10 +61,15 @@ const HomeFeedPage = () => {
 
   return (
     <Container>
+      {isLoggedIn && (
+        <PostTabWrapper>
+          <Tabs tabItems={tabList} tabIndicatorKind="line" cssProp={postTabCSS} />
+        </PostTabWrapper>
+      )}
       <InfiniteScrollContainer isLoaderShown={isFetching || isImagesFetching} onIntersect={handleIntersect}>
         <Feed
           infinitePostsData={infinitePostsData}
-          queryKey={[QUERY.GET_HOME_FEED_POSTS]}
+          queryKey={[QUERY.GET_HOME_FEED_POSTS(feedFilterOption)]}
           isFetching={isFetching || isImagesFetching}
         />
       </InfiniteScrollContainer>

--- a/frontend/src/services/queries/posts.ts
+++ b/frontend/src/services/queries/posts.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 import { QueryFunction, useInfiniteQuery, useMutation } from "react-query";
 
-import { ErrorResponse, Post } from "../../@types";
+import { ErrorResponse, FeedFilterOption, Post } from "../../@types";
 import { QUERY } from "../../constants/queries";
 import { getAccessToken } from "../../storage/storage";
 import { customError } from "../../utils/error";
@@ -37,11 +37,11 @@ const userPostsQueryFunction: QueryFunction<Post[]> = async ({ queryKey, pagePar
   }
 };
 
-export const useHomeFeedPostsQuery = () => {
+export const useHomeFeedPostsQuery = (feedFilterOption: FeedFilterOption) => {
   return useInfiniteQuery<Post[], AxiosError<ErrorResponse>>(
-    [QUERY.GET_HOME_FEED_POSTS],
+    [QUERY.GET_HOME_FEED_POSTS(feedFilterOption)],
     async ({ pageParam = 0 }) => {
-      return await requestGetHomeFeedPosts(pageParam, getAccessToken());
+      return await requestGetHomeFeedPosts(pageParam, feedFilterOption === "all" ? null : getAccessToken());
     },
     {
       getNextPageParam: (_, pages) => {

--- a/frontend/src/services/requests/posts.ts
+++ b/frontend/src/services/requests/posts.ts
@@ -14,8 +14,6 @@ export const requestGetHomeFeedPosts = async (pageParam: number, accessToken: st
       }
     : {};
 
-  // const response = await axios.get<Post[]>("http://localhost:3001/posts", config);
-
   const response = await axios.get<Post[]>(API_URL.POSTS(pageParam, LIMIT.FEED_COUNT_PER_FETCH), config);
 
   return response.data;


### PR DESCRIPTION
## 상세 내용
- 로그인 시 following, all 중 선택할 수 있는 탭이 나타난다.
- following 선택시 팔로잉하고 있는 유저의 게시물반 보여준다.
- all 선택 시 모든 게시물을 보여준다.
- 처음 로그인 시 default 상태로 following을 가진다.

<br>

https://user-images.githubusercontent.com/57767891/138060530-6ace15fb-87b1-4698-8fcb-038ffa499842.mov

<br>

Close #596 
