### PR TITLE
[#636] 피드 앵커링 이슈 해결

### DIFF
--- a/frontend/src/pages/SearchPostResultPage/SearchPostResultPage.tsx
+++ b/frontend/src/pages/SearchPostResultPage/SearchPostResultPage.tsx
@@ -28,7 +28,7 @@ interface LocationState {
 const SearchPostResultPage = () => {
   const [isMountedOnce, setIsMountedOnce] = useState(false);
   const [mountCounter, setMountCounter] = useState(0);
-  const containerRef = useRef<any>();
+  const ScrollWrapperRef = useRef<HTMLDivElement>(null);
   const { keyword } = useSearchKeyword();
   const type = new URLSearchParams(location.search).get("type") ?? "tags";
   const {
@@ -68,7 +68,7 @@ const SearchPostResultPage = () => {
 
     if (!isMountedOnce) {
       setMountCounter((prev) => prev + 1);
-      setIsMountedOnce(containerRef.current !== undefined);
+      setIsMountedOnce(ScrollWrapperRef.current !== null);
 
       return;
     }
@@ -76,7 +76,7 @@ const SearchPostResultPage = () => {
     const $targetPost = document.querySelector(`#post${postId}`);
 
     if ($targetPost && $targetPost instanceof HTMLElement) {
-      window.scrollTo(0, $targetPost.offsetTop - LayoutInPx.HEADER_HEIGHT);
+      ScrollWrapperRef.current?.scrollTo(0, $targetPost.offsetTop - LayoutInPx.HEADER_HEIGHT);
     }
   }, [postId, mountCounter, isMountedOnce]);
 
@@ -89,8 +89,8 @@ const SearchPostResultPage = () => {
   }
 
   return (
-    <ScrollPageWrapper>
-      <Container ref={containerRef}>
+    <ScrollPageWrapper ref={ScrollWrapperRef}>
+      <Container>
         <InfiniteScrollContainer isLoaderShown={isFetchingNextPage || isImagesFetching} onIntersect={handleIntersect}>
           <Feed
             infinitePostsData={infinitePostsData}

--- a/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
+++ b/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
@@ -23,7 +23,7 @@ interface LocationState {
 const UserFeedPage = () => {
   const [isMountedOnce, setIsMountedOnce] = useState(false);
   const [mountCounter, setMountCounter] = useState(0);
-  const containerRef = useRef<any>();
+  const scrollWrapperRef = useRef<HTMLDivElement>(null);
   const { currentUsername } = useAuth();
   const username = new URLSearchParams(location.search).get("username");
   const isMyFeed = currentUsername === username;
@@ -60,7 +60,7 @@ const UserFeedPage = () => {
 
     if (!isMountedOnce) {
       setMountCounter((prev) => prev + 1);
-      setIsMountedOnce(containerRef.current !== undefined);
+      setIsMountedOnce(scrollWrapperRef.current !== null);
 
       return;
     }
@@ -68,7 +68,7 @@ const UserFeedPage = () => {
     const $targetPost = document.querySelector(`#post${postId}`);
 
     if ($targetPost && $targetPost instanceof HTMLElement) {
-      window.scrollTo(0, $targetPost.offsetTop - LayoutInPx.HEADER_HEIGHT);
+      scrollWrapperRef.current?.scrollTo(0, $targetPost.offsetTop - LayoutInPx.HEADER_HEIGHT);
     }
   }, [postId, isMountedOnce, mountCounter]);
 
@@ -81,8 +81,8 @@ const UserFeedPage = () => {
   }
 
   return (
-    <ScrollPageWrapper>
-      <Container ref={containerRef}>
+    <ScrollPageWrapper ref={scrollWrapperRef}>
+      <Container>
         <InfiniteScrollContainer isLoaderShown={isFetchingNextPage || isImagesFetching} onIntersect={handleIntersect}>
           <Feed
             infinitePostsData={infinitePostsData}


### PR DESCRIPTION
## 상세 내용
- 스크롤 대상이 바뀌어 앵커링이 되지 않던 문제 해결

## 기타
- SearchPostResultPage나 UserFeed처럼 따로 스크롤을 통해 앵커링을 해주는 컴포넌트의 경우 아래 스크롤 ref를  overflow: scroll이 걸려있는 대상에 꼭 위치해주어야 합니다!

![스크린샷 2021-10-22 오후 4 32 38](https://user-images.githubusercontent.com/57767891/138412725-886454a9-e21a-4a62-a332-d62cb5882896.png)

<br/>

Close #636 
