### PR TITLE
[#638] 태그 클릭으로 검색이 되지 않는 이슈 해결

### DIFF
--- a/frontend/src/hooks/common/useSearchKeyword.ts
+++ b/frontend/src/hooks/common/useSearchKeyword.ts
@@ -9,7 +9,9 @@ const useSearchKeyword = () => {
     setKeyword("");
   };
 
-  const changeKeyword = (newKeyword: string) => setKeyword(newKeyword);
+  const changeKeyword = (newKeyword: string) => {
+    setKeyword(newKeyword);
+  };
 
   return { keyword, resetKeyword, changeKeyword };
 };

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -15,7 +15,7 @@ import useSearchKeyword from "../../hooks/common/useSearchKeyword";
 import useSearchPostData from "../../hooks/service/useSearchPostData";
 import useSearchUserData from "../../hooks/service/useSearchUserData";
 
-import { Container, ContentWrapper, Empty, KeywordsWrapper, NotFoundCSS } from "./SearchPage.style";
+import { Container, ContentWrapper, KeywordsWrapper, NotFoundCSS } from "./SearchPage.style";
 import { getItemsFromPages } from "../../utils/infiniteData";
 
 const tabNames = ["계정", "태그"];
@@ -28,10 +28,12 @@ const isSearchTypeValid = (type: string | null): type is keyof typeof searchType
 
 const SearchPage = () => {
   const type = new URLSearchParams(location.search).get("type");
+  const defaultKeyword = new URLSearchParams(location.search).get("keyword");
   const defaultTabIndex = isSearchTypeValid(type) ? searchTypeIndex[type] : 0;
   const [tabIndex, setTabIndex] = useState(defaultTabIndex);
+  const [isFirstMount, setIsFirstMount] = useState(true);
 
-  const { keyword, resetKeyword } = useSearchKeyword();
+  const { keyword, resetKeyword, changeKeyword } = useSearchKeyword();
   const formattedKeyword = keyword.trim().replace(/,/g, " ").replace(/\s+/g, " ");
 
   const {
@@ -50,6 +52,18 @@ const SearchPage = () => {
   } = useSearchPostData({ keyword: formattedKeyword, type: "tags", activated: tabIndex === 1 });
 
   useEffect(() => {
+    if (defaultKeyword) {
+      changeKeyword(defaultKeyword);
+    }
+  }, [defaultKeyword]);
+
+  useEffect(() => {
+    if (isFirstMount) {
+      setIsFirstMount(false);
+
+      return;
+    }
+
     resetKeyword();
   }, [tabIndex]);
 


### PR DESCRIPTION
## 상세 내용
- 원인: 탭 변경시 keyword를 초기화 하는 사이드 이펙트가 첫 마운트시에도 발생해 생긴 문제
- 해결: isFirstMount 상태를 추가해 첫 마운트시에는 keyword를 초기화하지 않도록 수정

<br/>

Close #638 
