### PR TITLE
[#685] 프로필 페이지 피드가 업데이트 되지 않는 이슈 해결

### DIFF
--- a/frontend/src/hooks/service/useUserFeed.ts
+++ b/frontend/src/hooks/service/useUserFeed.ts
@@ -76,7 +76,7 @@ const useUserFeed = (isMyFeed: boolean, username: string | null) => {
 
   useEffect(() => {
     initUserFeed(isMyFeed, username);
-  }, []);
+  }, [isMyFeed, username]);
 
   useEffect(() => {
     handleDataFetch();


### PR DESCRIPTION
## 상세 내용
- 피드 쿼리 키를 변경하는 이펙트에 username, isMyFeed에 대한 의존성 주입
- 굉장히 단순한 이슈였네요.. 역량 부족이 느껴집니다ㅜ

<br/>

Close #685 
