### PR TITLE
[#591] Async Logger 적용

### DIFF
--- a/backend/pick-git/build.gradle
+++ b/backend/pick-git/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'com.lmax:disruptor:3.4.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.httpcomponents:httpclient:4.5'
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'

--- a/backend/pick-git/src/main/resources/log4j2/log4j2-dev.xml
+++ b/backend/pick-git/src/main/resources/log4j2/log4j2-dev.xml
@@ -10,7 +10,7 @@
   </Properties>
 
   <Appenders>
-    <RollingFile name="InfoFileAppender" fileName="${info-log}.log" filePattern="${info-log}-${file-pattern}">
+    <RollingFile name="InfoFileAppender" fileName="${info-log}.log" filePattern="${info-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="DENY" onMismatch="NEUTRAL"/>
         <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
@@ -29,7 +29,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="WarnFileAppender" fileName="${warn-log}.log" filePattern="${warn-log}-${file-pattern}">
+    <RollingFile name="WarnFileAppender" fileName="${warn-log}.log" filePattern="${warn-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="DENY" onMismatch="NEUTRAL"/>
         <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
@@ -47,7 +47,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="ErrorFileAppender" fileName="${error-log}.log" filePattern="${error-log}-${file-pattern}">
+    <RollingFile name="ErrorFileAppender" fileName="${error-log}.log" filePattern="${error-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
@@ -63,7 +63,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="DbFileAppender" fileName="${db-log}.log" filePattern="${db-log}-${file-pattern}">
+    <RollingFile name="DbFileAppender" fileName="${db-log}.log" filePattern="${db-log}-${file-pattern}" immediateFlush="false">
       <PatternLayout pattern="${log-pattern}"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="15MB"/>
@@ -78,19 +78,19 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="com.woowacourse.pickgit" level="info" additivity="false">
+    <AsyncLogger name="com.woowacourse.pickgit" level="info" additivity="false" includeLocation="true">
       <AppenderRef ref="InfoFileAppender"/>
       <AppenderRef ref="WarnFileAppender"/>
       <AppenderRef ref="ErrorFileAppender"/>
-    </Logger>
-    <Logger name="org.springframework" level="info" additivity="false">
+    </AsyncLogger>
+    <AsyncLogger name="org.springframework" level="info" additivity="false" includeLocation="true">
       <AppenderRef ref="InfoFileAppender"/>
       <AppenderRef ref="WarnFileAppender"/>
       <AppenderRef ref="ErrorFileAppender"/>
-    </Logger>
-    <Logger name="org.hibernate.tool.hbm2ddl" level="debug" additivity="false">
+    </AsyncLogger>
+    <AsyncLogger name="org.hibernate.tool.hbm2ddl" level="debug" additivity="false" includeLocation="true">
       <appender-ref ref="DbFileAppender"/>
-    </Logger>
+    </AsyncLogger>
     <Root level="error">
       <AppenderRef ref="ErrorFileAppender"/>
     </Root>

--- a/backend/pick-git/src/main/resources/log4j2/log4j2-prod.xml
+++ b/backend/pick-git/src/main/resources/log4j2/log4j2-prod.xml
@@ -10,7 +10,7 @@
   </Properties>
 
   <Appenders>
-    <RollingFile name="InfoFileAppender" fileName="${info-log}.log" filePattern="${info-log}-${file-pattern}">
+    <RollingFile name="InfoFileAppender" fileName="${info-log}.log" filePattern="${info-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="DENY" onMismatch="NEUTRAL"/>
         <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
@@ -29,7 +29,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="WarnFileAppender" fileName="${warn-log}.log" filePattern="${warn-log}-${file-pattern}">
+    <RollingFile name="WarnFileAppender" fileName="${warn-log}.log" filePattern="${warn-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="DENY" onMismatch="NEUTRAL"/>
         <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="NEUTRAL"/>
@@ -47,7 +47,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="ErrorFileAppender" fileName="${error-log}.log" filePattern="${error-log}-${file-pattern}">
+    <RollingFile name="ErrorFileAppender" fileName="${error-log}.log" filePattern="${error-log}-${file-pattern}" immediateFlush="false">
       <Filters>
         <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
@@ -63,7 +63,7 @@
       </DefaultRolloverStrategy>
     </RollingFile>
 
-    <RollingFile name="DbFileAppender" fileName="${db-log}.log" filePattern="${db-log}-${file-pattern}">
+    <RollingFile name="DbFileAppender" fileName="${db-log}.log" filePattern="${db-log}-${file-pattern}" immediateFlush="false">
       <PatternLayout pattern="${log-pattern}"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="15MB"/>
@@ -78,19 +78,19 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="com.woowacourse.pickgit" level="info" additivity="false">
+    <AsyncLogger name="com.woowacourse.pickgit" level="info" additivity="false" includeLocation="true">
       <AppenderRef ref="InfoFileAppender"/>
       <AppenderRef ref="WarnFileAppender"/>
       <AppenderRef ref="ErrorFileAppender"/>
-    </Logger>
-    <Logger name="org.springframework" level="info" additivity="false">
+    </AsyncLogger>
+    <AsyncLogger name="org.springframework" level="info" additivity="false" includeLocation="true">
       <AppenderRef ref="InfoFileAppender"/>
       <AppenderRef ref="WarnFileAppender"/>
       <AppenderRef ref="ErrorFileAppender"/>
-    </Logger>
-    <Logger name="org.hibernate.tool.hbm2ddl" level="debug" additivity="false">
+    </AsyncLogger>
+    <AsyncLogger name="org.hibernate.tool.hbm2ddl" level="debug" additivity="false" includeLocation="true">
       <appender-ref ref="DbFileAppender"/>
-    </Logger>
+    </AsyncLogger>
     <Root level="error">
       <AppenderRef ref="ErrorFileAppender"/>
     </Root>


### PR DESCRIPTION
## 상세 내용

이것저것 테스트해보느라 늦었네요

* http://tech.pick-git.com/logback-vs-log4j2/

성능 관련한 내용은 위를 참조해주시면 감사하겠습니다.

짧게 요약해보자면

1. Logback과 Log4j2 모두 ArrayBlockingQueue를 사용하는 AsyncAppender (비동기 로깅) 기능을 제공합니다.
2. Log4j2는 이에 그치지 않고  LMAX Disruptor라는 Lock-Free Inter-Thread Communication 라이브러리를 사용함으로써, 더 높은 처리량 및 낮은 지연 시간을 달성했습니다.
3. 완벽한 테스트는 아니지만 성능이 향상된것을 확인할 수 있습니다.

## 비동기 로깅?

간단하게 요약해보자면

일반적으로 동기적인 환경에서 ``logger.error("에러발생")`` 같은 코드가 호출되면, 발생한 로그를 처리할수 있는 Logger 객체가 로그를 작성합니다. FileAppender라면 I/O가 발생하겠죠~ 이게 트래픽이 높은 환경에서 트랜잭션 내부에서 매 로그 발생마다 File IO가 발생하면 성능에 영향을 미칩니다.

비동기 로깅은 로그 발생(``logger.error()``)이 나면 바로 I/O가 발생하지 않고, 다른 스레드의 Queue에 기록할 로그들을 담아두고 처리하는 방식입니다. 즉, **로그 발생과 쓰기 작업을 분리합니다.**

## 단점

1. 시스템이 꺼지면 큐에 담긴 로그들이 소실됩니다.
2. 로그 큐가 일정 메모리 한계에 도달하면 로그를 유실할수있습니다.
3. 에러 발생 위치를 기록하지 못합니다.


2번, 3번의 경우 옵션 설정을 통해 유실되지 않도록 블락킹 옵션을 주고, 위치를 기록하도록 수정할 수 있습니다. 다만 로그 발생 위치를 기록하게 되면 성능이 다소 저하되기는 합니다.

[공식문서](https://logging.apache.org/log4j/2.x/manual/async.html)


## 테스트 결과 요약

* 로그 발생 위치를 기록해도 동기적인 로그 방식보다 성능이 우수합니다.

<br/>

## 기타

사실 우리 서비스에서 로깅이 드라마틱한 성능 이슈를 야기하지 않고 있어서 크게 중요한 사안은 아니긴합니다. :(

<br/>

Close #591 
