### PR TITLE
[#731] 리포지터리 검색 시 빈 alert 창이 뜨는 문제 해결

### DIFF
--- a/frontend/src/services/requests/github.ts
+++ b/frontend/src/services/requests/github.ts
@@ -27,7 +27,7 @@ export const requestGetTags = async (repositoryName: string, accessToken: string
   }
 
   if (repositoryName === "") {
-    throw customError.emptyRepositoryName;
+    return [];
   }
 
   const response = await axios.get<Tags>(API_URL.GITHUB_TAGS(repositoryName), {

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -33,5 +33,4 @@ export const getClientErrorMessage = (errorCode: ClientErrorCode) => {
 export const customError = {
   noAccessToken: Error("C0001"),
   fileReader: Error("C0002"),
-  emptyRepositoryName: Error("P0002"),
 };


### PR DESCRIPTION
## 상세 내용

- repository name 이 비워진 채 검색을 수행하면 그냥 빈 데이터가 반환되도록 수정
<br/>

Close #731
