### PR TITLE
[#747] 포트폴리오 업데이트가 안되는 버그를 해결

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/section/item/Item.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/section/item/Item.java
@@ -85,7 +85,7 @@ public class Item implements Updatable<Item> {
     public void update(Item item) {
         item.getDescriptions().forEach(description -> description.appendTo(this));
 
-        UpdateUtil.execute(item.getDescriptions(), this.getDescriptions());
+        UpdateUtil.execute(this.getDescriptions(), item.getDescriptions());
     }
 
     @Override


### PR DESCRIPTION
 ## 상세 내용

업데이트 로직의 source와 target을 반대로 넣어주고 있었음.

<br/>

## 기타

<br/>

Close #747 
