### PR TITLE
[#735] 홈피드가 새로운 상태를 반영하지 않는 이슈 해결

### DIFF
--- a/frontend/src/components/Feed/Feed.stories.tsx
+++ b/frontend/src/components/Feed/Feed.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story = (args) => {
       {...args}
       infinitePostsData={infinitePostsData}
       onIntersect={() => {}}
-      queryKey={QUERY.GET_HOME_FEED_POSTS("all")}
+      queryKeyList={[QUERY.GET_HOME_FEED_POSTS("all")]}
       isFetching={false}
     />
   );

--- a/frontend/src/components/Feed/Feed.tsx
+++ b/frontend/src/components/Feed/Feed.tsx
@@ -23,15 +23,22 @@ interface Props {
   infinitePostsData: InfiniteData<Post[] | null>;
   onIntersect: () => void;
   setCurrentPostId?: Dispatch<SetStateAction<number>>;
-  queryKey: QueryKey;
+  queryKeyList: QueryKey[];
   isFetching: boolean;
   notFoundMessage?: string | null;
 }
 
-const Feed = ({ infinitePostsData, onIntersect, setCurrentPostId, queryKey, isFetching, notFoundMessage }: Props) => {
+const Feed = ({
+  infinitePostsData,
+  onIntersect,
+  setCurrentPostId,
+  queryKeyList,
+  isFetching,
+  notFoundMessage,
+}: Props) => {
   const [selectedPostId, setSelectedPostId] = useState<Post["id"]>();
   const { pushSnackbarMessage } = useContext(SnackBarContext);
-  const { addPostLike, deletePost, deletePostLike, isDeletePostLoading } = useFeedMutation(queryKey);
+  const { addPostLike, deletePost, deletePostLike, isDeletePostLoading } = useFeedMutation(queryKeyList);
   const [posts, setPosts] = useState<Post[]>([]);
   const { setPostEditData } = usePostEdit();
   const {

--- a/frontend/src/contexts/HomeFeedContext.tsx
+++ b/frontend/src/contexts/HomeFeedContext.tsx
@@ -2,9 +2,9 @@ import { AxiosError } from "axios";
 import { createContext, Dispatch, SetStateAction, useEffect, useState } from "react";
 import { UseInfiniteQueryResult } from "react-query";
 
-import { ErrorResponse, FeedFilterOption, Post } from "../@types";
-import useAuth from "../hooks/common/useAuth";
 import { useHomeFeedAllPostsQuery, useHomeFeedFollowingsPostsQuery } from "../services/queries";
+
+import { ErrorResponse, FeedFilterOption, Post } from "../@types";
 
 interface Props {
   children: React.ReactNode;
@@ -18,6 +18,7 @@ interface Value {
   currentPostId: number;
   initialized: boolean;
   initHomeFeed: () => void;
+  refetchAll: () => void;
   setFeedFilterOption: Dispatch<SetStateAction<FeedFilterOption>>;
   setCurrentPostId: Dispatch<SetStateAction<number>>;
 }
@@ -39,6 +40,14 @@ export const HomeFeedContextProvider = ({ children }: Props) => {
     setInitialized(true);
   };
 
+  const refetchAll = () => {
+    Object.values(queryResults).forEach((query) => query.refetch());
+  };
+
+  useEffect(() => {
+    refetchAll();
+  }, [feedFilterOption]);
+
   return (
     <HomeFeedContext.Provider
       value={{
@@ -47,6 +56,7 @@ export const HomeFeedContextProvider = ({ children }: Props) => {
         currentPostId,
         initialized,
         initHomeFeed,
+        refetchAll,
         setFeedFilterOption,
         setCurrentPostId,
       }}

--- a/frontend/src/hooks/service/useHomeFeed.ts
+++ b/frontend/src/hooks/service/useHomeFeed.ts
@@ -15,10 +15,18 @@ import HomeFeedContext from "../../contexts/HomeFeedContext";
 import useAuth from "../common/useAuth";
 
 const tmp: { current: FeedFilterOption | null } = { current: null };
+const queryKeyList = [QUERY.GET_HOME_FEED_POSTS("followings"), QUERY.GET_HOME_FEED_POSTS("all")];
 
 const useHomeFeed = () => {
-  const { queryResults, feedFilterOption, currentPostId, initialized, setFeedFilterOption, setCurrentPostId } =
-    useContext(HomeFeedContext);
+  const {
+    queryResults,
+    feedFilterOption,
+    currentPostId,
+    initialized,
+    setFeedFilterOption,
+    setCurrentPostId,
+    refetchAll,
+  } = useContext(HomeFeedContext);
 
   const {
     data: infinitePostsData,
@@ -31,7 +39,7 @@ const useHomeFeed = () => {
   } = queryResults[feedFilterOption];
 
   // TODO : 그냥 QUERY 만 보내도 되는지 알아보기
-  const { setPostsPages } = useFeedMutation([QUERY]);
+  const { setPostsPages } = useFeedMutation(queryKeyList);
   const { isLoggedIn, logout } = useAuth();
   const queryClient = useQueryClient();
 
@@ -65,7 +73,7 @@ const useHomeFeed = () => {
 
     const filteredPages = infinitePostsData.pages.map((page) => removeDuplicatedData<Post>(page, (page) => page.id));
 
-    setPostsPages(filteredPages);
+    queryKeyList.forEach((queryKey) => setPostsPages(filteredPages, queryKey));
   };
 
   useEffect(() => {
@@ -87,6 +95,7 @@ const useHomeFeed = () => {
     currentPostId,
     setFeedFilterOption,
     setCurrentPostId,
+    refetchAll,
   };
 };
 

--- a/frontend/src/pages/AddPostPage/AddPostPage.tsx
+++ b/frontend/src/pages/AddPostPage/AddPostPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import axios from "axios";
 import { Container, StepSlider, StepContainer, NextStepButtonWrapper } from "./AddPostPage.style";
 
@@ -30,8 +30,10 @@ import {
 } from "../../utils/postUpload";
 import { getAPIErrorMessage } from "../../utils/error";
 import { ScrollPageWrapper } from "../../components/@styled/layout";
+import HomeFeedContext from "../../contexts/HomeFeedContext";
 
 const AddPostPage = () => {
+  const { refetchAll: refetchHomeFeed } = useContext(HomeFeedContext);
   const { pushSnackbarMessage } = useSnackbar();
   const {
     modalMessage: alertMessage,

--- a/frontend/src/pages/HomeFeedPage/HomeFeedPage.tsx
+++ b/frontend/src/pages/HomeFeedPage/HomeFeedPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import PageLoadingWithLogo from "../../components/@layout/PageLoadingWithLogo/PageLoadingWithLogo";
 import PageError from "../../components/@shared/PageError/PageError";
 import Tabs from "../../components/@shared/Tabs/Tabs";
@@ -26,6 +27,7 @@ const HomeFeedPage = () => {
     currentPostId,
     setFeedFilterOption,
     setCurrentPostId,
+    refetchAll,
   } = useHomeFeed();
   const { scrollWrapperRef } = useAutoAnchor(`#post${currentPostId}`);
 
@@ -45,6 +47,11 @@ const HomeFeedPage = () => {
     handlePostsEndIntersect();
     activateImageFetchingState();
   };
+
+  useEffect(() => {
+    refetchAll();
+    setTimeout(refetchAll, 300);
+  }, []);
 
   if (isLoading || isFirstImagesLoading) {
     return <PageLoadingWithLogo />;
@@ -70,7 +77,7 @@ const HomeFeedPage = () => {
         <Feed
           infinitePostsData={infinitePostsData}
           onIntersect={handleIntersect}
-          queryKey={[QUERY.GET_HOME_FEED_POSTS(feedFilterOption)]}
+          queryKeyList={[QUERY.GET_HOME_FEED_POSTS("followings"), QUERY.GET_HOME_FEED_POSTS("all")]}
           isFetching={isFetching || isImagesFetching}
           setCurrentPostId={setCurrentPostId}
           notFoundMessage={feedFilterOption === "followings" ? NOT_FOUND_MESSAGE.POSTS.FOLLOWINGS : null}

--- a/frontend/src/pages/SearchPostResultPage/SearchPostResultPage.tsx
+++ b/frontend/src/pages/SearchPostResultPage/SearchPostResultPage.tsx
@@ -73,7 +73,7 @@ const SearchPostResultPage = () => {
         <Feed
           infinitePostsData={infinitePostsData}
           onIntersect={handleIntersect}
-          queryKey={[QUERY.GET_SEARCH_POST_RESULT, { type, keyword }]}
+          queryKeyList={[[QUERY.GET_SEARCH_POST_RESULT, { type, keyword }]]}
           isFetching={isFetchingNextPage || isImagesFetching}
           setCurrentPostId={setCurrentPostId}
         />

--- a/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
+++ b/frontend/src/pages/UserFeedPage/UserFeedPage.tsx
@@ -66,7 +66,7 @@ const UserFeedPage = () => {
         <Feed
           infinitePostsData={infinitePostsData}
           onIntersect={handleIntersect}
-          queryKey={[QUERY.GET_USER_FEED_POSTS, { username, isMyFeed }]}
+          queryKeyList={[[QUERY.GET_USER_FEED_POSTS, { username, isMyFeed }]]}
           isFetching={isFetchingNextPage || isImagesFetching}
           setCurrentPostId={setCurrentPostId}
         />

--- a/frontend/src/services/queries/posts.ts
+++ b/frontend/src/services/queries/posts.ts
@@ -48,7 +48,7 @@ const postQueryFunction: QueryFunction<Post> = async ({ queryKey }) => {
 
 export const useHomeFeedFollowingsPostsQuery = () => {
   return useInfiniteQuery<Post[] | null, AxiosError<ErrorResponse>>(
-    [QUERY.GET_HOME_FEED_POSTS("followings")],
+    QUERY.GET_HOME_FEED_POSTS("followings"),
     async ({ pageParam = 0 }) => {
       return await requestGetHomeFeedPosts(pageParam, getAccessToken(), "followings");
     },
@@ -57,13 +57,14 @@ export const useHomeFeedFollowingsPostsQuery = () => {
         return pages.length;
       },
       cacheTime: 0,
+      refetchOnMount: "always",
     }
   );
 };
 
 export const useHomeFeedAllPostsQuery = () => {
   return useInfiniteQuery<Post[] | null, AxiosError<ErrorResponse>>(
-    [QUERY.GET_HOME_FEED_POSTS("all")],
+    QUERY.GET_HOME_FEED_POSTS("all"),
     async ({ pageParam = 0 }) => {
       return await requestGetHomeFeedPosts(pageParam, getAccessToken(), "all");
     },
@@ -72,6 +73,7 @@ export const useHomeFeedAllPostsQuery = () => {
         return pages.length;
       },
       cacheTime: 0,
+      refetchOnMount: "always",
     }
   );
 };


### PR DESCRIPTION
## 상세 내용
- 게시물 업로드, 수정, 삭제 즉시 반영
- 양쪽 탭 좋아요 상태 동기화
- 댓글 추가 삭제 즉시 반영
- 팔로우 여부 즉시 반영

<br/>

Close #735 
