### PR TITLE
[#763] portfolio가 생성이 안되는 버그를 해결.

### DIFF
--- a/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/Portfolio.java
+++ b/backend/pick-git/src/main/java/com/woowacourse/pickgit/portfolio/domain/Portfolio.java
@@ -124,7 +124,7 @@ public class Portfolio {
             user.getName(),
             true,
             user.getImage(),
-            user.getDescription(),
+            Objects.isNull(user.getDescription()) ? "" : user.getDescription(),
             LocalDateTime.now(),
             LocalDateTime.now(),
             Contacts.empty(),


### PR DESCRIPTION
## 상세 내용

사용자의 GitHub discription이 없을 경우 프로트폴리오 생성 시 한줄 소개란이 null로 들어가면서 null point exception이 발생합니다.

<br/>

## 기타

<br/>

Close #763